### PR TITLE
adds support for github codespaces for fast, portable dev env setup (plus minimal fixes)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,15 @@
+# Using GitHub Codespaces with devcontainers for Semantic Workbench
+
+- Create app registration at https://portal.azure.com
+  - Manage > Authentication > Single-page application > Redirect URI's
+  - Add `https://<YOUR_CODESPACE_HOST>-4000.app.github.dev`
+  - Copy the Application (client) ID from Overview
+- Update `constants.ts` with the Application (client) ID
+- Update `middleware.py` with the Application (client) ID
+- Use VS Code > Run and Debug > `Semantic Workbench` to start both the app and the service
+- After launching semantic-workbench-service, go to Ports and make 3000 public
+
+## TODO
+
+- [ ] Add support for reading Application (client) ID from environment variables
+- [ ] Improve this README with details on App Registration setup, and more detailed steps

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,8 +1,9 @@
 # Using GitHub Codespaces with devcontainers for Semantic Workbench
 
 - Create app registration at https://portal.azure.com
-  - Manage > Authentication > Single-page application > Redirect URI's
-  - Add `https://<YOUR_CODESPACE_HOST>-4000.app.github.dev`
+  - Name: Semantic Workbench
+  - Supported account types: Accounts in any organizational directory and personal Microsoft accounts
+  - Redirect URI: Single-page application (SPA) & `https://<YOUR_CODESPACE_HOST>-4000.app.github.dev`
   - Copy the Application (client) ID from Overview
 - Update `constants.ts` with the Application (client) ID
 - Update `middleware.py` with the Application (client) ID

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,76 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "semantic-workbench",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+	
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/poetry:2": {
+			"version": "latest"
+		},
+		"ghcr.io/jungaretti/features/make:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"installYarnUsingApt": true,
+			"version": "lts",
+			"nvmVersion": "latest"
+		},
+		// "ghcr.io/devcontainers/features/azure-cli:1": {}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000, 4000],
+
+	// Use 'portsAttributes' to configure the behavior of specific port forwarding instances.
+	"portsAttributes": {
+		"3000": {
+			"label": "service:semantic-workbench",
+			"protocol": "http"
+		},
+		"4000": {
+			"label": "app:semantic-workbench",
+			"protocol": "https"
+		}
+	},
+
+	// Use 'otherPortsAttributes' to set the defaults that are applied to all ports, unless overridden
+	// with port-specific entries in 'portsAttributes'.
+	// "otherPortsAttributes": {},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": {
+		// Build and restore dependencies for key projects in the repo
+		"make_workbench_app": "make -C /workspaces/semantic-workbench/v1/app",
+		"make_workbench_service": "make -C /workspaces/semantic-workbench/v1/service"
+	},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+            "extensions": [
+                "GitHub.copilot",
+				"aaron-bond.better-comments",
+				"aarontamasfe.even-better-toml",
+				"dbaeumer.vscode-eslint",
+				"esbenp.prettier-vscode",
+				"ms-python.black-formatter",
+				"ms-python.flake8",
+				"ms-python.python",
+            ]
+        }
+	}
+
+	// Uncomment to run commands after the container is created.
+	// "containerEnv": {
+	//  Disabled because it is being applied twice for the app because something else is setting it
+	//  and appears to be adding it to whatever it is already set to. The reason I was adding it was
+	//  to increase the memory limit across the whole container for pylance.  Alternate "fix" may be
+	//  to use a higher capacity container and/or fewer open projects in the workspace.
+	// 	"NODE_OPTIONS": "--max-old-space-size=8192"
+	// }
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,76 +1,76 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
-	"name": "semantic-workbench",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+  "name": "semantic-workbench",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
-		"ghcr.io/devcontainers-contrib/features/poetry:2": {
-			"version": "latest"
-		},
-		"ghcr.io/jungaretti/features/make:1": {},
-		"ghcr.io/devcontainers/features/node:1": {
-			"nodeGypDependencies": true,
-			"installYarnUsingApt": true,
-			"version": "lts",
-			"nvmVersion": "latest"
-		}
-		// "ghcr.io/devcontainers/features/azure-cli:1": {}
-	},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/poetry:2": {
+      "version": "latest"
+    },
+    "ghcr.io/jungaretti/features/make:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "nodeGypDependencies": true,
+      "installYarnUsingApt": true,
+      "version": "lts",
+      "nvmVersion": "latest"
+    }
+    // "ghcr.io/devcontainers/features/azure-cli:1": {}
+  },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [3000, 4000],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000, 4000],
 
-	// Use 'portsAttributes' to configure the behavior of specific port forwarding instances.
-	"portsAttributes": {
-		"3000": {
-			"label": "service:semantic-workbench",
-			"protocol": "http"
-		},
-		"4000": {
-			"label": "app:semantic-workbench",
-			"protocol": "https"
-		}
-	},
+  // Use 'portsAttributes' to configure the behavior of specific port forwarding instances.
+  "portsAttributes": {
+    "3000": {
+      "label": "service:semantic-workbench",
+      "protocol": "http"
+    },
+    "4000": {
+      "label": "app:semantic-workbench",
+      "protocol": "https"
+    }
+  },
 
-	// Use 'otherPortsAttributes' to set the defaults that are applied to all ports, unless overridden
-	// with port-specific entries in 'portsAttributes'.
-	// "otherPortsAttributes": {},
+  // Use 'otherPortsAttributes' to set the defaults that are applied to all ports, unless overridden
+  // with port-specific entries in 'portsAttributes'.
+  // "otherPortsAttributes": {},
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": {
-		// Build and restore dependencies for key projects in the repo
-		"make_workbench_app": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/app",
-		"make_workbench_service": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/service"
-	},
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": {
+    // Build and restore dependencies for key projects in the repo
+    "make_workbench_app": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/app",
+    "make_workbench_service": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/service"
+  },
 
-	// Configure tool-specific properties.
-	// "customizations": {
-	// 	"vscode": {
-    //         "extensions": [
-    //             "GitHub.copilot",
-	// 			"aaron-bond.better-comments",
-	// 			"aarontamasfe.even-better-toml",
-	// 			"dbaeumer.vscode-eslint",
-	// 			"esbenp.prettier-vscode",
-	// 			"ms-python.black-formatter",
-	// 			"ms-python.flake8",
-	// 			"ms-python.python"
-    //         ]
-    //     }
-	// }
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "GitHub.copilot",
+        "aaron-bond.better-comments",
+        "aarontamasfe.even-better-toml",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.python"
+      ]
+    }
+  }
 
-	// Uncomment to run commands after the container is created.
-	// "containerEnv": {
-	//  Disabled because it is being applied twice for the app because something else is setting it
-	//  and appears to be adding it to whatever it is already set to. The reason I was adding it was
-	//  to increase the memory limit across the whole container for pylance.  Alternate "fix" may be
-	//  to use a higher capacity container and/or fewer open projects in the workspace.
-	// 	"NODE_OPTIONS": "--max-old-space-size=8192"
-	// }
+  // Uncomment to run commands after the container is created.
+  // "containerEnv": {
+  //  Disabled because it is being applied twice for the app because something else is setting it
+  //  and appears to be adding it to whatever it is already set to. The reason I was adding it was
+  //  to increase the memory limit across the whole container for pylance.  Alternate "fix" may be
+  //  to use a higher capacity container and/or fewer open projects in the workspace.
+  // 	"NODE_OPTIONS": "--max-old-space-size=8192"
+  // }
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "semantic-workbench",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
-	
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/poetry:2": {
@@ -16,7 +16,7 @@
 			"installYarnUsingApt": true,
 			"version": "lts",
 			"nvmVersion": "latest"
-		},
+		}
 		// "ghcr.io/devcontainers/features/azure-cli:1": {}
 	},
 
@@ -42,25 +42,25 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": {
 		// Build and restore dependencies for key projects in the repo
-		"make_workbench_app": "make -C /workspaces/semantic-workbench/v1/app",
-		"make_workbench_service": "make -C /workspaces/semantic-workbench/v1/service"
+		"make_workbench_app": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/app",
+		"make_workbench_service": "make -C /workspaces/semanticworkbench/semantic-workbench/v1/service"
 	},
 
 	// Configure tool-specific properties.
-	"customizations": {
-		"vscode": {
-            "extensions": [
-                "GitHub.copilot",
-				"aaron-bond.better-comments",
-				"aarontamasfe.even-better-toml",
-				"dbaeumer.vscode-eslint",
-				"esbenp.prettier-vscode",
-				"ms-python.black-formatter",
-				"ms-python.flake8",
-				"ms-python.python",
-            ]
-        }
-	}
+	// "customizations": {
+	// 	"vscode": {
+    //         "extensions": [
+    //             "GitHub.copilot",
+	// 			"aaron-bond.better-comments",
+	// 			"aarontamasfe.even-better-toml",
+	// 			"dbaeumer.vscode-eslint",
+	// 			"esbenp.prettier-vscode",
+	// 			"ms-python.black-formatter",
+	// 			"ms-python.flake8",
+	// 			"ms-python.python"
+    //         ]
+    //     }
+	// }
 
 	// Uncomment to run commands after the container is created.
 	// "containerEnv": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "semantic-workbench-app",
+      "cwd": "${workspaceFolder}/semantic-workbench/v1/app",
+      "skipFiles": ["<node_internals>/**"],
+      "console": "integratedTerminal",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"]
+    },
+    {
+      "type": "debugpy",
+      "request": "launch",
+      "name": "semantic-workbench-service",
+      "cwd": "${workspaceFolder}/semantic-workbench/v1/service",
+      "module": "semantic_workbench_service.start",
+      "justMyCode": false,
+      "consoleTitle": "semantic-workbench-service",
+      "args": ["--host", "0.0.0.0", "--port", "3000"]
+    },
+    {
+      "type": "debugpy",
+      "request": "launch",
+      "name": "canonical-assistant",
+      "cwd": "${workspaceFolder}/semantic-workbench/v1/service",
+      "module": "semantic_workbench_assistant.start",
+      "args": ["semantic_workbench_assistant.canonical:app", "--port", "3002"],
+      "consoleTitle": "canonical-assistant"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "semantic-workbench",
+      "configurations": ["semantic-workbench-app", "semantic-workbench-service"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,157 @@
+{
+  "black-formatter.args": ["--config", "service/.black.toml"],
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
+  },
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "flake8.args": ["--config", "service/.flake8"],
+  "isort.args": ["--profile", "black", "--gitignore"],
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "python.analysis.autoFormatStrings": true,
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.diagnosticMode": "workspace",
+  "python.analysis.exclude": [
+    "**/node_modules/**",
+    "**/.venv/**",
+    "**/.data/**",
+    "**/__pycache__/**"
+  ],
+  "python.analysis.fixAll": ["source.unusedImports"],
+  "python.analysis.inlayHints.functionReturnTypes": true,
+  "python.analysis.typeCheckingMode": "basic",
+  "python.defaultInterpreterPath": "${workspaceFolder}/semantic-workbench/v1/service/.venv",
+  "python.languageServer": "Pylance",
+  "python.testing.pytestEnabled": true,
+  "python.testing.cwd": "${workspaceFolder:v1}/service",
+  "python.testing.pytestArgs": [],
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.codeActionsOnSave": {
+      "source.unusedImports": "explicit",
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit",
+      "source.formatDocument": "explicit"
+    }
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit",
+      "source.fixAll": "explicit"
+    }
+  },
+  "css.lint.validProperties": ["composes"],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.lintTask.enable": true,
+  "editor.formatOnPaste": true,
+  "editor.formatOnType": true,
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+  "javascript.updateImportsOnFileMove.enabled": "always",
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/build": true,
+    "**/.venv": true
+  },
+  "typescript.updateImportsOnFileMove.enabled": "always",
+  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "files.associations": { "*.json": "jsonc" },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true
+  },
+  "editor.bracketPairColorization.enabled": true,
+  "editor.guides.bracketPairs": "active",
+  "eslint.options": {
+    "overrideConfigFile": ".eslintrc.cjs"
+  },
+  "better-comments.highlightPlainText": true,
+  "better-comments.multilineComments": true,
+  "better-comments.tags": [
+    {
+      "tag": "!",
+      "color": "#FF2D00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "?",
+      "color": "#3498DB",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "//",
+      "color": "#474747",
+      "strikethrough": true,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "todo",
+      "color": "#FF8C00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "fixme",
+      "color": "#FF2D00",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    },
+    {
+      "tag": "*",
+      "color": "#98C379",
+      "strikethrough": false,
+      "underline": false,
+      "backgroundColor": "transparent",
+      "bold": false,
+      "italic": false
+    }
+  ]
+}

--- a/semantic-workbench/v1/app/src/Constants.ts
+++ b/semantic-workbench/v1/app/src/Constants.ts
@@ -17,7 +17,7 @@ export const Constants = {
         environments: [
             {
                 id: 'local',
-                name: 'Semantic Workbench backend service on localhost',
+                name: 'Semantic Workbench backend service on localhost or GitHub Codespaces',
                 url: 'http://localhost:3000',
                 brand: 'light',
             },

--- a/semantic-workbench/v1/app/src/libs/useEnvironment.ts
+++ b/semantic-workbench/v1/app/src/libs/useEnvironment.ts
@@ -22,7 +22,7 @@ export const getEnvironment = (environmentId?: string): ServiceEnvironment => {
     if (environmentId) {
         const environment = Constants.service.environments.find((environment) => environment.id === environmentId);
         if (environment) {
-            return environment;
+            return transformEnvironment(environment);
         }
     }
 
@@ -30,8 +30,19 @@ export const getEnvironment = (environmentId?: string): ServiceEnvironment => {
         (environment) => environment.id === Constants.service.defaultEnvironmentId,
     );
     if (defaultEnvironment) {
-        return defaultEnvironment;
+        return transformEnvironment(defaultEnvironment);
     }
 
     throw new Error('No default environment found. Check Constants.ts file.');
+};
+
+const transformEnvironment = (environment: ServiceEnvironment) => {
+    if (window.location.hostname.includes('-4000.app.github.dev') && environment.id === 'local') {
+        return {
+            ...environment,
+            url: window.location.origin.replace('-4000.app.github.dev', '-3000.app.github.dev'),
+        };
+    }
+
+    return environment;
 };

--- a/semantic-workbench/v1/app/src/routes/Settings.tsx
+++ b/semantic-workbench/v1/app/src/routes/Settings.tsx
@@ -42,11 +42,9 @@ export const Settings: React.FC = () => {
 
     siteUtility.setDocumentTitle('Settings');
 
-    if (assistantServiceRegistrationsError) {
-        throw new Error(
-            `Error loading assistant service registrations: ${JSON.stringify(assistantServiceRegistrationsError)}`,
-        );
-    }
+    // Don't throw on assistant service registration error,
+    // instead show the error message in the UI and allow the
+    // rest of the settings page to render.
 
     const handleEnvironmentChange = React.useCallback(
         (environmentId: string) => {
@@ -111,11 +109,15 @@ export const Settings: React.FC = () => {
                     </div>
                 )} */}
             </Card>
-            <Card className={classes.card}>
-                <Field label="Assistant Service Registrations">
-                    <MyAssistantServiceRegistrations assistantServiceRegistrations={assistantServiceRegistrations} />
-                </Field>
-            </Card>
+            {!assistantServiceRegistrationsError && (
+                <Card className={classes.card}>
+                    <Field label="Assistant Service Registrations">
+                        <MyAssistantServiceRegistrations
+                            assistantServiceRegistrations={assistantServiceRegistrations}
+                        />
+                    </Field>
+                </Card>
+            )}
         </AppView>
     );
 };

--- a/semantic-workbench/v1/service/semantic-workbench-service/semantic_workbench_service/controller/conversation.py
+++ b/semantic-workbench/v1/service/semantic-workbench-service/semantic_workbench_service/controller/conversation.py
@@ -110,7 +110,7 @@ class ConversationController:
             assistant = (
                 await session.exec(
                     query.select_assistants_for(user_principal=user_principal).where(
-                        db.Assistant.assistant_id == str(assistant_id)
+                        db.Assistant.assistant_id == assistant_id
                     )
                 )
             ).one_or_none()
@@ -449,7 +449,7 @@ class ConversationController:
                             assistant = (
                                 await session.exec(
                                     query.select_assistants_for(user_principal=principal).where(
-                                        db.Assistant.assistant_id == participant_id
+                                        db.Assistant.assistant_id == uuid.UUID(participant_id)
                                     )
                                 )
                             ).one_or_none()
@@ -476,7 +476,7 @@ class ConversationController:
                         raise exceptions.ForbiddenError()
 
                     assistant = (
-                        await session.exec(select(db.Assistant).where(db.Assistant.assistant_id == participant_id))
+                        await session.exec(select(db.Assistant).where(db.Assistant.assistant_id == uuid.UUID(participant_id)))
                     ).one_or_none()
                     if assistant is None:
                         raise exceptions.NotFoundError()

--- a/semantic-workbench/v1/service/semantic-workbench-service/semantic_workbench_service/middleware.py
+++ b/semantic-workbench/v1/service/semantic-workbench-service/semantic_workbench_service/middleware.py
@@ -82,9 +82,13 @@ async def _user_principal_from_request(request: Request) -> auth.UserPrincipal |
         logger.debug("No access token found in request, using ID token")
         token = idToken
 
-    if "." not in accessToken:
+    if accessToken is not None and "." not in accessToken:
         logger.debug("Access token not JWT, using ID token")
         token = idToken
+
+    if token is None:
+        logger.debug("No token found in request")
+        return None
 
     try:
         algorithm: str = jwt.get_unverified_header(token).get("alg") or ""


### PR DESCRIPTION
Using GH Codespaces, a dev can launch a browser instance of VS Code running the full env needed for Semantic Workbench in just a few minutes, full automated.  This PR also includes the necessary .vscode launch configuration for run/debug w/ the UI and a minimal/intro readme for this approach.

Also applied a few small fixes for issues encountered while testing up to running the canonical assistant, including the fixes submitted in the other open PR (at the time of opening this one).

Includes recommended settings and extensions that we've found useful in our dev of this solution, but since they are our opinions, can either remain simply as recommendations or removed before merging if that is preferred.