### PR TITLE
examples: improve support for case sensitive filesystem

### DIFF
--- a/examples/dotnet-01-echo-bot/Program.cs
+++ b/examples/dotnet-01-echo-bot/Program.cs
@@ -17,6 +17,7 @@ internal static class Program
         appBuilder.Configuration
             .AddJsonFile("appsettings.json")
             .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddJsonFile("appsettings.development.json", optional: true)
             .AddEnvironmentVariables();
 
         // Storage layer to persist agents configuration and conversations

--- a/examples/dotnet-02-message-types-demo/Program.cs
+++ b/examples/dotnet-02-message-types-demo/Program.cs
@@ -20,6 +20,7 @@ internal static class Program
         appBuilder.Configuration
             .AddJsonFile("appsettings.json")
             .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddJsonFile("appsettings.development.json", optional: true)
             .AddEnvironmentVariables();
 
         // Storage layer to persist agents configuration and conversations

--- a/examples/dotnet-03-simple-chatbot/Program.cs
+++ b/examples/dotnet-03-simple-chatbot/Program.cs
@@ -20,6 +20,7 @@ internal static class Program
         appBuilder.Configuration
             .AddJsonFile("appsettings.json")
             .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddJsonFile("appsettings.development.json", optional: true)
             .AddEnvironmentVariables();
 
         appBuilder.Services


### PR DESCRIPTION
When running on Windows or other case sensitive filesystems, the config file might be `appsettings.Development.json` or `appsettings.development.json`, leading to config errors if the exact name is not used.
This PR allows to use both in the examples, so it's easier to run them.