### PR TITLE
Remove explicit pyright excludes

### DIFF
--- a/assistants/prospector-assistant/.vscode/settings.json
+++ b/assistants/prospector-assistant/.vscode/settings.json
@@ -21,11 +21,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/assistants/prospector-assistant/pyproject.toml
+++ b/assistants/prospector-assistant/pyproject.toml
@@ -37,6 +37,3 @@ document-skill = { path = "../../libraries/python/skills/skills/document-skill",
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/assistants/skill-assistant/.vscode/settings.json
+++ b/assistants/skill-assistant/.vscode/settings.json
@@ -22,12 +22,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**",
-    "**/.pytest_cache/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/assistants/skill-assistant/pyproject.toml
+++ b/assistants/skill-assistant/pyproject.toml
@@ -28,6 +28,3 @@ posix-skill = { path = "../../libraries/python/skills/skills/posix-skill", edita
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/examples/python/python-01-echo-bot/.vscode/settings.json
+++ b/examples/python/python-01-echo-bot/.vscode/settings.json
@@ -21,11 +21,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/examples/python/python-01-echo-bot/pyproject.toml
+++ b/examples/python/python-01-echo-bot/pyproject.toml
@@ -16,6 +16,3 @@ semantic-workbench-assistant = { path = "../../../libraries/python/semantic-work
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/examples/python/python-02-simple-chatbot/.vscode/settings.json
+++ b/examples/python/python-02-simple-chatbot/.vscode/settings.json
@@ -21,11 +21,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/examples/python/python-02-simple-chatbot/pyproject.toml
+++ b/examples/python/python-02-simple-chatbot/pyproject.toml
@@ -22,6 +22,3 @@ content-safety = { path = "../../../libraries/python/content-safety/", editable 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/examples/python/python-03-multimodel-chatbot/.vscode/settings.json
+++ b/examples/python/python-03-multimodel-chatbot/.vscode/settings.json
@@ -21,11 +21,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/examples/python/python-03-multimodel-chatbot/pyproject.toml
+++ b/examples/python/python-03-multimodel-chatbot/pyproject.toml
@@ -24,6 +24,3 @@ content-safety = { path = "../../../libraries/python/content-safety/", editable 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/libraries/python/chat-driver/.vscode/settings.json
+++ b/libraries/python/chat-driver/.vscode/settings.json
@@ -11,29 +11,17 @@
   "editor.guides.bracketPairs": "active",
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
-  "flake8.ignorePatterns": [
-    "**/*.py"
-  ], // disable flake8 in favor of ruff
+  "flake8.ignorePatterns": ["**/*.py"], // disable flake8 in favor of ruff
   "jupyter.debugJustMyCode": false,
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
-  "python.analysis.fixAll": [
-    "source.unusedImports"
-  ],
+  "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
-  "python.testing.pytestArgs": [
-    "--color",
-    "yes"
-  ],
+  "python.testing.pytestArgs": ["--color", "yes"],
   "python.testing.pytestEnabled": true,
   "search.exclude": {
     "**/.venv": true,

--- a/libraries/python/chat-driver/pyproject.toml
+++ b/libraries/python/chat-driver/pyproject.toml
@@ -34,6 +34,3 @@ function-registry = { path = "../function-registry", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/content-safety/.vscode/settings.json
+++ b/libraries/python/content-safety/.vscode/settings.json
@@ -21,11 +21,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/content-safety/pyproject.toml
+++ b/libraries/python/content-safety/pyproject.toml
@@ -22,6 +22,3 @@ semantic-workbench-assistant = { path = "../semantic-workbench-assistant", edita
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = ["venv", ".venv"]

--- a/libraries/python/context/.vscode/settings.json
+++ b/libraries/python/context/.vscode/settings.json
@@ -11,29 +11,17 @@
   "editor.guides.bracketPairs": "active",
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
-  "flake8.ignorePatterns": [
-    "**/*.py"
-  ], // disable flake8 in favor of ruff
+  "flake8.ignorePatterns": ["**/*.py"], // disable flake8 in favor of ruff
   "jupyter.debugJustMyCode": false,
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
-  "python.analysis.fixAll": [
-    "source.unusedImports"
-  ],
+  "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
-  "python.testing.pytestArgs": [
-    "--color",
-    "yes"
-  ],
+  "python.testing.pytestArgs": ["--color", "yes"],
   "python.testing.pytestEnabled": true,
   "search.exclude": {
     "**/.venv": true,

--- a/libraries/python/context/pyproject.toml
+++ b/libraries/python/context/pyproject.toml
@@ -23,6 +23,3 @@ events = { path = "../events", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/events/.vscode/settings.json
+++ b/libraries/python/events/.vscode/settings.json
@@ -11,29 +11,17 @@
   "editor.guides.bracketPairs": "active",
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
-  "flake8.ignorePatterns": [
-    "**/*.py"
-  ], // disable flake8 in favor of ruff
+  "flake8.ignorePatterns": ["**/*.py"], // disable flake8 in favor of ruff
   "jupyter.debugJustMyCode": false,
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
-  "python.analysis.fixAll": [
-    "source.unusedImports"
-  ],
+  "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
-  "python.testing.pytestArgs": [
-    "--color",
-    "yes"
-  ],
+  "python.testing.pytestArgs": ["--color", "yes"],
   "python.testing.pytestEnabled": true,
   "search.exclude": {
     "**/.venv": true,

--- a/libraries/python/events/pyproject.toml
+++ b/libraries/python/events/pyproject.toml
@@ -20,6 +20,3 @@ dev-dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/function-registry/.vscode/settings.json
+++ b/libraries/python/function-registry/.vscode/settings.json
@@ -11,29 +11,17 @@
   "editor.guides.bracketPairs": "active",
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
-  "flake8.ignorePatterns": [
-    "**/*.py"
-  ], // disable flake8 in favor of ruff
+  "flake8.ignorePatterns": ["**/*.py"], // disable flake8 in favor of ruff
   "jupyter.debugJustMyCode": false,
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
-  "python.analysis.fixAll": [
-    "source.unusedImports"
-  ],
+  "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
-  "python.testing.pytestArgs": [
-    "--color",
-    "yes"
-  ],
+  "python.testing.pytestArgs": ["--color", "yes"],
   "python.testing.pytestEnabled": true,
   "search.exclude": {
     "**/.venv": true,

--- a/libraries/python/function-registry/pyproject.toml
+++ b/libraries/python/function-registry/pyproject.toml
@@ -30,6 +30,3 @@ context = { path = "../context", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/semantic-workbench-api-model/.vscode/settings.json
+++ b/libraries/python/semantic-workbench-api-model/.vscode/settings.json
@@ -18,12 +18,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/node_modules/**",
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/semantic-workbench-api-model/pyproject.toml
+++ b/libraries/python/semantic-workbench-api-model/pyproject.toml
@@ -16,6 +16,3 @@ package = true
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/semantic-workbench-assistant/.vscode/settings.json
+++ b/libraries/python/semantic-workbench-assistant/.vscode/settings.json
@@ -30,11 +30,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/semantic-workbench-assistant/pyproject.toml
+++ b/libraries/python/semantic-workbench-assistant/pyproject.toml
@@ -35,9 +35,6 @@ start-semantic-workbench-assistant = "semantic_workbench_assistant.start:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.pyright]
-exclude = [".venv"]
-
 [tool.pytest.ini_options]
 addopts = "-vv"
 log_cli = true

--- a/libraries/python/skills/notebooks/.vscode/settings.json
+++ b/libraries/python/skills/notebooks/.vscode/settings.json
@@ -15,11 +15,6 @@
   "jupyter.debugJustMyCode": false,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/notebooks/pyproject.toml
+++ b/libraries/python/skills/notebooks/pyproject.toml
@@ -29,17 +29,3 @@ chat-driver = { path = "../../chat-driver", editable = true }
 context = { path = "../../context", editable = true }
 events = { path = "../../events", editable = true }
 function-registry = { path = "../../function-registry", editable = true }
-
-[tool.pyright]
-exclude = [
-    "__pycache__",
-    ".vscode",
-    ".ipynb_checkpoints",
-    "build",
-    "dist",
-    "venv",
-    ".venv",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".git",
-]

--- a/libraries/python/skills/skill-library/.vscode/settings.json
+++ b/libraries/python/skills/skill-library/.vscode/settings.json
@@ -16,11 +16,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/skill-library/pyproject.toml
+++ b/libraries/python/skills/skill-library/pyproject.toml
@@ -30,6 +30,3 @@ function-registry = { path = "../../function-registry", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/skills/skills/document-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/document-skill/.vscode/settings.json
@@ -15,11 +15,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/skills/document-skill/pyproject.toml
+++ b/libraries/python/skills/skills/document-skill/pyproject.toml
@@ -28,6 +28,3 @@ events = { path = "../../../events", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/skills/skills/posix-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/posix-skill/.vscode/settings.json
@@ -16,11 +16,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/skills/posix-skill/pyproject.toml
+++ b/libraries/python/skills/skills/posix-skill/pyproject.toml
@@ -29,6 +29,3 @@ events = { path = "../../../events", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/skills/skills/prospector-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/prospector-skill/.vscode/settings.json
@@ -16,11 +16,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/skills/prospector-skill/pyproject.toml
+++ b/libraries/python/skills/skills/prospector-skill/pyproject.toml
@@ -24,6 +24,3 @@ events = { path = "../../../events", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/libraries/python/skills/skills/skill-template/.vscode/settings.json
+++ b/libraries/python/skills/skills/skill-template/.vscode/settings.json
@@ -16,11 +16,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/libraries/python/skills/skills/skill-template/pyproject.toml
+++ b/libraries/python/skills/skills/skill-template/pyproject.toml
@@ -23,6 +23,3 @@ events = { path = "../../../events", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-[tool.pyright]
-exclude = [".venv"]

--- a/workbench-service/.vscode/settings.json
+++ b/workbench-service/.vscode/settings.json
@@ -30,11 +30,6 @@
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.diagnosticMode": "workspace",
-  "python.analysis.exclude": [
-    "**/.venv/**",
-    "**/.data/**",
-    "**/__pycache__/**"
-  ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/workbench-service/pyproject.toml
+++ b/workbench-service/pyproject.toml
@@ -51,9 +51,6 @@ start-semantic-workbench-service = "semantic_workbench_service.start:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.pyright]
-exclude = [".venv"]
-
 [tool.pytest.ini_options]
 addopts = "-vv"
 log_cli = true


### PR DESCRIPTION
Now that all of our excludes are now the defaults for pyright: ['**/node_modules', '**/__pycache__', '**/.*']