### PR TITLE
"Live" validates config in the UI

### DIFF
--- a/assistants/prospector-assistant/.env.example
+++ b/assistants/prospector-assistant/.env.example
@@ -1,6 +1,11 @@
 # Description: Example of .env file
 # Usage: Copy this file to .env and set the values
 
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
+
 # Assistant Service
 ASSISTANT__AZURE_OPENAI_ENDPOINT=https://<YOUR-RESOURCE-NAME>.openai.azure.com/
 ASSISTANT__AZURE_CONTENT_SAFETY_ENDPOINT=https://<YOUR-RESOURCE-NAME>.cognitiveservices.azure.com/

--- a/assistants/prospector-assistant/.vscode/launch.json
+++ b/assistants/prospector-assistant/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "assistants: prospector-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app", "--port", "3011"],
+      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/prospector-assistant/assistant/chat.py
+++ b/assistants/prospector-assistant/assistant/chat.py
@@ -54,7 +54,7 @@ service_description = "An assistant that helps you mine ideas from artifacts."
 #
 # create the configuration provider, using the extended configuration model
 #
-assistant_config = BaseModelAssistantConfig(AssistantConfigModel())
+assistant_config = BaseModelAssistantConfig(AssistantConfigModel)
 
 
 # define the content safety evaluator factory

--- a/assistants/prospector-assistant/assistant/config.py
+++ b/assistants/prospector-assistant/assistant/config.py
@@ -218,7 +218,7 @@ class AssistantConfigModel(BaseModel):
         ),
     ] = RequestConfig()
 
-    service_config: openai_client.ServiceConfig = openai_client.AzureOpenAIServiceConfig()
+    service_config: openai_client.ServiceConfig
 
     content_safety_config: Annotated[
         CombinedContentSafetyEvaluatorConfig,

--- a/assistants/skill-assistant/.env.example
+++ b/assistants/skill-assistant/.env.example
@@ -1,6 +1,11 @@
 # Description: Example of .env file
 # Usage: Copy this file to .env and set the values
 
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
+
 # Assistant Service
 ASSISTANT__AZURE_OPENAI_ENDPOINT=https://<YOUR-RESOURCE-NAME>.openai.azure.com/
 ASSISTANT__AZURE_CONTENT_SAFETY_ENDPOINT=https://<YOUR-RESOURCE-NAME>.cognitiveservices.azure.com/

--- a/assistants/skill-assistant/.vscode/launch.json
+++ b/assistants/skill-assistant/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "assistants: skill-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.skill_assistant:app", "--port", "3012"],
+      "args": ["assistant.skill_assistant:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/skill-assistant/assistant/config.py
+++ b/assistants/skill-assistant/assistant/config.py
@@ -119,7 +119,7 @@ class AssistantConfigModel(BaseModel):
         ),
     ] = ChatDriverConfig()
 
-    service_config: openai_client.ServiceConfig = openai_client.AzureOpenAIServiceConfig()
+    service_config: openai_client.ServiceConfig
 
     content_safety_config: Annotated[
         CombinedContentSafetyEvaluatorConfig,

--- a/examples/python/python-01-echo-bot/.env.example
+++ b/examples/python/python-01-echo-bot/.env.example
@@ -1,8 +1,10 @@
 # Description: Example of .env file
 # Usage: Copy this file to .env and set the values
 
-# NOTE: Changes to this file will not take effect until the project service is 'stopped' and 'started'
-# It is not enough to just use the VS Code 'restart' button
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
 
 # Assistant Service
 # The ASSISTANT__ prefix is used to group all the environment variables related to the assistant service.

--- a/examples/python/python-01-echo-bot/.vscode/launch.json
+++ b/examples/python/python-01-echo-bot/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "examples: python-01-echo-bot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app", "--port", "3001"],
+      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/examples/python/python-01-echo-bot/assistant/chat.py
+++ b/examples/python/python-01-echo-bot/assistant/chat.py
@@ -57,9 +57,7 @@ service_description = "A starter for building a chat assistant using the Semanti
 #
 # create the configuration provider, using the extended configuration model
 #
-assistant_config = BaseModelAssistantConfig(
-    default=AssistantConfigModel(),
-)
+assistant_config = BaseModelAssistantConfig(AssistantConfigModel)
 
 content_safety = ContentSafety(AlwaysWarnContentSafetyEvaluator.factory)
 

--- a/examples/python/python-02-simple-chatbot/.env.example
+++ b/examples/python/python-02-simple-chatbot/.env.example
@@ -1,8 +1,10 @@
 # Description: Example of .env file
 # Usage: Copy this file to .env and set the values
 
-# NOTE: Changes to this file will not take effect until the project service is 'stopped' and 'started'
-# It is not enough to just use the VS Code 'restart' button
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
 
 # Assistant Service
 ASSISTANT__AZURE_OPENAI_ENDPOINT=https://<YOUR-RESOURCE-NAME>.openai.azure.com/

--- a/examples/python/python-02-simple-chatbot/.vscode/launch.json
+++ b/examples/python/python-02-simple-chatbot/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "examples: python-02-simple-chatbot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app", "--port", "3002"],
+      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/examples/python/python-02-simple-chatbot/assistant/chat.py
+++ b/examples/python/python-02-simple-chatbot/assistant/chat.py
@@ -63,7 +63,7 @@ service_description = "A simple OpenAI chat assistant using the Semantic Workben
 #
 # create the configuration provider, using the extended configuration model
 #
-assistant_config = BaseModelAssistantConfig(AssistantConfigModel())
+assistant_config = BaseModelAssistantConfig(AssistantConfigModel)
 
 
 # define the content safety evaluator factory

--- a/examples/python/python-02-simple-chatbot/assistant/config.py
+++ b/examples/python/python-02-simple-chatbot/assistant/config.py
@@ -135,7 +135,7 @@ class AssistantConfigModel(BaseModel):
         ),
     ] = RequestConfig()
 
-    service_config: openai_client.ServiceConfig = openai_client.AzureOpenAIServiceConfig()
+    service_config: openai_client.ServiceConfig
 
     content_safety_config: Annotated[
         CombinedContentSafetyEvaluatorConfig,

--- a/examples/python/python-03-multimodel-chatbot/.env.example
+++ b/examples/python/python-03-multimodel-chatbot/.env.example
@@ -1,8 +1,10 @@
 # Description: Example of .env file
 # Usage: Copy this file to .env and set the values
 
-# NOTE: Changes to this file will not take effect until the project service is 'stopped' and 'started'
-# It is not enough to just use the VS Code 'restart' button
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
 
 # Assistant Service
 ASSISTANT__AZURE_OPENAI_ENDPOINT=https://<YOUR-RESOURCE-NAME>.openai.azure.com/

--- a/examples/python/python-03-multimodel-chatbot/.vscode/launch.json
+++ b/examples/python/python-03-multimodel-chatbot/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "examples: python-03-multimodel-chatbot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app", "--port", "3003"],
+      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}",
       "justMyCode": false
     }

--- a/examples/python/python-03-multimodel-chatbot/assistant/chat.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/chat.py
@@ -62,7 +62,7 @@ service_description = "A chat assistant supporting multiple AI models using the 
 #
 # create the configuration provider, using the extended configuration model
 #
-assistant_config = BaseModelAssistantConfig(AssistantConfigModel())
+assistant_config = BaseModelAssistantConfig(AssistantConfigModel)
 
 
 # define the content safety evaluator factory

--- a/examples/python/python-03-multimodel-chatbot/assistant/config.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/config.py
@@ -340,7 +340,7 @@ class AssistantConfigModel(BaseModel):
             discriminator="service_type",
         ),
         UISchema(widget="radio", hide_title=True),
-    ] = AzureOpenAIServiceConfig()
+    ] = AzureOpenAIServiceConfig.model_construct()
 
     content_safety_config: Annotated[
         CombinedContentSafetyEvaluatorConfig,

--- a/libraries/python/content-safety/content_safety/evaluators/azure_content_safety/evaluator.py
+++ b/libraries/python/content-safety/content_safety/evaluators/azure_content_safety/evaluator.py
@@ -103,7 +103,7 @@ class AzureContentSafetyEvaluator(ContentSafetyEvaluator):
         # send the text to the Azure Content Safety service for evaluation
         try:
             response = ContentSafetyClient(
-                endpoint=self.config.azure_content_safety_endpoint,
+                endpoint=str(self.config.azure_content_safety_endpoint),
                 credential=self.config._get_azure_credentials(),
             ).analyze_text(AnalyzeTextOptions(text=text))
         except Exception as e:

--- a/libraries/python/content-safety/content_safety/evaluators/config.py
+++ b/libraries/python/content-safety/content_safety/evaluators/config.py
@@ -16,4 +16,4 @@ class CombinedContentSafetyEvaluatorConfig(BaseModel):
             title="Content Safety Evaluator",
         ),
         UISchema(widget="radio", hide_title=True),
-    ] = AzureContentSafetyEvaluatorConfig()
+    ] = AzureContentSafetyEvaluatorConfig.model_construct()

--- a/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
+++ b/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 class OpenAIContentSafetyEvaluatorConfig(BaseModel):
     model_config = ConfigDict(
         title="OpenAI Content Safety Evaluator",
+        json_schema_extra={
+            "required": ["openai_api_key"],
+        },
     )
 
     service_type: Annotated[
@@ -63,7 +66,7 @@ class OpenAIContentSafetyEvaluatorConfig(BaseModel):
             title="OpenAI API Key",
             description="The API key to use for the OpenAI API.",
         ),
-    ] = ""
+    ]
 
 
 # endregion

--- a/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
+++ b/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
@@ -60,7 +60,6 @@ class OpenAIContentSafetyEvaluatorConfig(BaseModel):
     openai_api_key: Annotated[
         ConfigSecretStr,
         Field(
-            default="",
             title="OpenAI API Key",
             description="The API key to use for the OpenAI API.",
         ),

--- a/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
+++ b/libraries/python/content-safety/content_safety/evaluators/openai_moderations/config.py
@@ -63,7 +63,7 @@ class OpenAIContentSafetyEvaluatorConfig(BaseModel):
             title="OpenAI API Key",
             description="The API key to use for the OpenAI API.",
         ),
-    ]
+    ] = ""
 
 
 # endregion

--- a/libraries/python/openai-client/.vscode/settings.json
+++ b/libraries/python/openai-client/.vscode/settings.json
@@ -1,0 +1,36 @@
+{
+  "editor.bracketPairColorization.enabled": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
+  },
+  "editor.guides.bracketPairs": "active",
+  "editor.formatOnPaste": true,
+  "editor.formatOnType": true,
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "python.analysis.autoFormatStrings": true,
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.diagnosticMode": "workspace",
+  "python.analysis.fixAll": ["source.unusedImports"],
+  "python.analysis.inlayHints.functionReturnTypes": true,
+  "python.analysis.typeCheckingMode": "basic",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.unusedImports": "explicit",
+      "source.organizeImports": "explicit",
+      "source.formatDocument": "explicit"
+    }
+  },
+  "ruff.nativeServer": "on",
+  "search.exclude": {
+    "**/.venv": true,
+    "**/.data": true,
+    "**/__pycache__": true
+  }
+}

--- a/libraries/python/openai-client/openai_client/client.py
+++ b/libraries/python/openai-client/openai_client/client.py
@@ -21,7 +21,7 @@ def create_client(service_config: ServiceConfig, *, api_version: str = "2024-08-
                     return AsyncAzureOpenAI(
                         api_key=service_config.auth_config.azure_openai_api_key,
                         azure_deployment=service_config.azure_openai_deployment,
-                        azure_endpoint=service_config.azure_openai_endpoint,
+                        azure_endpoint=str(service_config.azure_openai_endpoint),
                         api_version=api_version,
                     )
 
@@ -29,7 +29,7 @@ def create_client(service_config: ServiceConfig, *, api_version: str = "2024-08-
                     return AsyncAzureOpenAI(
                         azure_ad_token_provider=_get_azure_bearer_token_provider(),
                         azure_deployment=service_config.azure_openai_deployment,
-                        azure_endpoint=service_config.azure_openai_endpoint,
+                        azure_endpoint=str(service_config.azure_openai_endpoint),
                         api_version=api_version,
                     )
 

--- a/libraries/python/openai-client/openai_client/client.py
+++ b/libraries/python/openai-client/openai_client/client.py
@@ -1,12 +1,16 @@
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.lib.azure import AsyncAzureADTokenProvider
-from .config import ServiceConfig, AzureOpenAIApiKeyAuthConfig, AzureOpenAIAzureIdentityAuthConfig, AzureOpenAIServiceConfig, OpenAIServiceConfig
+from .config import (
+    ServiceConfig,
+    AzureOpenAIApiKeyAuthConfig,
+    AzureOpenAIAzureIdentityAuthConfig,
+    AzureOpenAIServiceConfig,
+    OpenAIServiceConfig,
+)
 
 
-def create_client(
-    service_config: ServiceConfig, *, api_version: str = "2024-08-01-preview"
-) -> AsyncOpenAI:
+def create_client(service_config: ServiceConfig, *, api_version: str = "2024-08-01-preview") -> AsyncOpenAI:
     """
     Creates an AsyncOpenAI client based on the provided service configuration.
     """
@@ -30,8 +34,7 @@ def create_client(
                     )
 
                 case _:
-                    raise ValueError(
-                        f"Invalid auth method type: {type(service_config.auth_config)}")
+                    raise ValueError(f"Invalid auth method type: {type(service_config.auth_config)}")
 
         case OpenAIServiceConfig():
             return AsyncOpenAI(
@@ -40,8 +43,7 @@ def create_client(
             )
 
         case _:
-            raise ValueError(
-                f"Invalid service config type: {type(service_config)}")
+            raise ValueError(f"Invalid service config type: {type(service_config)}")
 
 
 _lazy_initialized_azure_bearer_token_provider = None

--- a/libraries/python/openai-client/openai_client/config.py
+++ b/libraries/python/openai-client/openai_client/config.py
@@ -31,8 +31,7 @@ class AzureOpenAIApiKeyAuthConfig(BaseModel):
         },
     )
 
-    auth_method: Annotated[Literal[AuthMethodType.APIKey],
-                           UISchema(widget="hidden")] = AuthMethodType.APIKey
+    auth_method: Annotated[Literal[AuthMethodType.APIKey], UISchema(widget="hidden")] = AuthMethodType.APIKey
 
     azure_openai_api_key: Annotated[
         # ConfigSecretStr is a custom type that should be used for any secrets.
@@ -42,7 +41,7 @@ class AzureOpenAIApiKeyAuthConfig(BaseModel):
             title="Azure OpenAI API Key",
             description="The Azure OpenAI API key for your resource instance.",
         ),
-    ] = ""
+    ]
 
 
 class AzureOpenAIServiceConfig(BaseModel):
@@ -53,17 +52,17 @@ class AzureOpenAIServiceConfig(BaseModel):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.AzureOpenAI], UISchema(
-        widget="hidden")] = ServiceType.AzureOpenAI
+    service_type: Annotated[Literal[ServiceType.AzureOpenAI], UISchema(widget="hidden")] = ServiceType.AzureOpenAI
 
     auth_config: Annotated[
         AzureOpenAIAzureIdentityAuthConfig | AzureOpenAIApiKeyAuthConfig,
         Field(
             title="Authentication method",
             description="The authentication method to use for the Azure OpenAI API.",
+            default=AzureOpenAIAzureIdentityAuthConfig(),
         ),
         UISchema(widget="radio", hide_title=True),
-    ] = AzureOpenAIAzureIdentityAuthConfig()
+    ]
 
     azure_openai_endpoint: Annotated[
         HttpUrl,
@@ -73,8 +72,7 @@ class AzureOpenAIServiceConfig(BaseModel):
                 "The Azure OpenAI endpoint for your resource instance. If not provided, the service default will"
                 " be used."
             ),
-            default=first_env_var("azure_openai_endpoint",
-                                  "assistant__azure_openai_endpoint") or "",
+            default=first_env_var("azure_openai_endpoint", "assistant__azure_openai_endpoint") or "",
         ),
     ]
 
@@ -83,18 +81,15 @@ class AzureOpenAIServiceConfig(BaseModel):
         Field(
             title="Azure OpenAI Deployment",
             description="The Azure OpenAI deployment to use.",
-            default=first_env_var(
-                "azure_openai_deployment", "assistant__azure_openai_deployment") or "gpt-4o",
+            default=first_env_var("azure_openai_deployment", "assistant__azure_openai_deployment") or "gpt-4o",
         ),
     ]
 
 
 class OpenAIServiceConfig(BaseModel):
-    model_config = ConfigDict(title="OpenAI", json_schema_extra={
-                              "required": ["openai_api_key"]})
+    model_config = ConfigDict(title="OpenAI", json_schema_extra={"required": ["openai_api_key"]})
 
-    service_type: Annotated[Literal[ServiceType.OpenAI],
-                            UISchema(widget="hidden")] = ServiceType.OpenAI
+    service_type: Annotated[Literal[ServiceType.OpenAI], UISchema(widget="hidden")] = ServiceType.OpenAI
 
     openai_api_key: Annotated[
         # ConfigSecretStr is a custom type that should be used for any secrets.
@@ -104,7 +99,7 @@ class OpenAIServiceConfig(BaseModel):
             title="OpenAI API Key",
             description="The API key to use for the OpenAI API.",
         ),
-    ] = ""
+    ]
 
     # spell-checker: ignore rocrupyvzgcl4yf25rqq6d1v
     openai_organization_id: Annotated[
@@ -116,9 +111,10 @@ class OpenAIServiceConfig(BaseModel):
                 " name. If you do not specify an organization ID, the default organization will be used. Example:"
                 " org-rocrupyvzgcl4yf25rqq6d1v"
             ),
+            default="",
         ),
         UISchema(placeholder="[optional]"),
-    ] = ""
+    ]
 
 
 ServiceConfig = Annotated[

--- a/libraries/python/openai-client/openai_client/config.py
+++ b/libraries/python/openai-client/openai_client/config.py
@@ -42,7 +42,7 @@ class AzureOpenAIApiKeyAuthConfig(BaseModel):
             title="Azure OpenAI API Key",
             description="The Azure OpenAI API key for your resource instance.",
         ),
-    ]
+    ] = ""
 
 
 class AzureOpenAIServiceConfig(BaseModel):
@@ -90,7 +90,8 @@ class AzureOpenAIServiceConfig(BaseModel):
 
 
 class OpenAIServiceConfig(BaseModel):
-    model_config = ConfigDict(title="OpenAI")
+    model_config = ConfigDict(title="OpenAI", json_schema_extra={
+                              "required": ["openai_api_key"]})
 
     service_type: Annotated[Literal[ServiceType.OpenAI],
                             UISchema(widget="hidden")] = ServiceType.OpenAI
@@ -103,7 +104,7 @@ class OpenAIServiceConfig(BaseModel):
             title="OpenAI API Key",
             description="The API key to use for the OpenAI API.",
         ),
-    ]
+    ] = ""
 
     # spell-checker: ignore rocrupyvzgcl4yf25rqq6d1v
     openai_organization_id: Annotated[

--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/assistant_model.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/assistant_model.py
@@ -42,6 +42,7 @@ class StatePutRequestModel(BaseModel):
 
 class ConfigResponseModel(BaseModel):
     config: dict[str, Any]
+    errors: list[str] | None
     json_schema: dict[str, Any] | None
     ui_schema: dict[str, Any] | None
 

--- a/libraries/python/semantic-workbench-assistant/.vscode/launch.json
+++ b/libraries/python/semantic-workbench-assistant/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "canonical-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["semantic_workbench_assistant.canonical:app", "--port", "3100"],
+      "args": ["semantic_workbench_assistant.canonical:app"],
       "consoleTitle": "canonical-assistant"
     }
   ]

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/assistant.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/assistant.py
@@ -31,7 +31,7 @@ class AssistantApp:
         assistant_service_id: str,
         assistant_service_name: str,
         assistant_service_description: str,
-        config_provider: AssistantConfigProvider = BaseModelAssistantConfig(EmptyConfigModel()).provider,
+        config_provider: AssistantConfigProvider = BaseModelAssistantConfig(EmptyConfigModel).provider,
         data_exporter: AssistantDataExporter = FileStorageAssistantDataExporter(),
         conversation_data_exporter: ConversationDataExporter = FileStorageConversationDataExporter(),
         inspector_state_providers: Mapping[str, AssistantConversationInspectorStateProvider] | None = None,

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/protocol.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/protocol.py
@@ -76,6 +76,7 @@ class ConversationDataExporter(Protocol):
 @dataclass
 class AssistantConfigDataModel:
     config: dict[str, Any]
+    errors: list[str] | None = field(default=None)
     json_schema: dict[str, Any] | None = field(default=None)
     ui_schema: dict[str, Any] | None = field(default=None)
 

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
@@ -226,6 +226,7 @@ class AssistantService(FastAPIAssistantService):
             description=self.service_description,
             default_config=assistant_model.ConfigResponseModel(
                 config=default_config.config,
+                errors=default_config.errors,
                 json_schema=default_config.json_schema,
                 ui_schema=default_config.ui_schema,
             ),
@@ -307,6 +308,7 @@ class AssistantService(FastAPIAssistantService):
         config = await self.assistant_app._config_provider.get(assistant_context)
         return assistant_model.ConfigResponseModel(
             config=config.config,
+            errors=config.errors,
             json_schema=config.json_schema,
             ui_schema=config.ui_schema,
         )

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/config.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/config.py
@@ -24,21 +24,24 @@ def first_env_var(*env_vars: str, include_upper_and_lower: bool = True, include_
 
     Args:
         include_upper_and_lower: if True, then the UPPER and lower case versions of the env vars will be checked.
-        include_dot_env: if True, then the .env file will be checked for the env vars.
+        include_dot_env: if True, then the .env file will be checked for the env vars after the os.
     """
     if include_upper_and_lower:
         env_vars = (*env_vars, *[env_var.upper() for env_var in env_vars], *[env_var.lower() for env_var in env_vars])
-
-    dot_env_values = {}
-    if include_dot_env:
-        dotenv_path = dotenv.find_dotenv(usecwd=True)
-        if dotenv_path:
-            dot_env_values = dotenv.dotenv_values(dotenv_path)
 
     for env_var in env_vars:
         if env_var in os.environ:
             return os.environ[env_var]
 
+    if not include_dot_env:
+        return None
+
+    dotenv_path = dotenv.find_dotenv(usecwd=True)
+    if not dotenv_path:
+        return None
+
+    dot_env_values = dotenv.dotenv_values(dotenv_path)
+    for env_var in env_vars:
         if env_var in dot_env_values:
             return dot_env_values[env_var]
 

--- a/libraries/python/semantic-workbench-assistant/tests/test_assistant_app.py
+++ b/libraries/python/semantic-workbench-assistant/tests/test_assistant_app.py
@@ -340,7 +340,7 @@ async def test_assistant_with_config_provider(
         test_key: str = "test_value"
         secret_field: ConfigSecretStr = "secret_default"
 
-    config_provider = BaseModelAssistantConfig(TestConfigModel()).provider
+    config_provider = BaseModelAssistantConfig(TestConfigModel).provider
     # wrap the provider so we can check calls to it
     config_provider_wrapper = mock.Mock(wraps=config_provider)
 
@@ -373,6 +373,7 @@ async def test_assistant_with_config_provider(
         response = await instance_client.get_config()
         assert response == assistant_model.ConfigResponseModel(
             config={"test_key": "test_value", "secret_field": "**********"},
+            errors=[],
             json_schema=TestConfigModel.model_json_schema(),
             ui_schema=expected_ui_schema,
         )
@@ -385,6 +386,7 @@ async def test_assistant_with_config_provider(
         )
         assert response == assistant_model.ConfigResponseModel(
             config={"test_key": "new_value", "secret_field": "**********"},
+            errors=[],
             json_schema=TestConfigModel.model_json_schema(),
             ui_schema=expected_ui_schema,
         )
@@ -399,6 +401,7 @@ async def test_assistant_with_config_provider(
         response = await instance_client.get_config()
         assert response == assistant_model.ConfigResponseModel(
             config={"test_key": "new_value", "secret_field": "**********"},
+            errors=[],
             json_schema=TestConfigModel.model_json_schema(),
             ui_schema=expected_ui_schema,
         )
@@ -432,6 +435,7 @@ async def test_assistant_with_config_provider(
         )
         assert response == assistant_model.ConfigResponseModel(
             config={"test_key": "new_value", "secret_field": ""},
+            errors=[],
             json_schema=TestConfigModel.model_json_schema(),
             ui_schema=expected_ui_schema,
         )

--- a/libraries/python/skills/notebooks/.env.example
+++ b/libraries/python/skills/notebooks/.env.example
@@ -1,3 +1,8 @@
+# NOTE:
+# - Environment variables in the host environment will take precedence over values in this file.
+# - When running with VS Code, you must 'stop' and 'start' the process for changes to take effect.
+#   It is not enough to just use the VS Code 'restart' button
+
 AZURE_OPENAI_ENDPOINT="https://lightspeed-team-shared-openai-eastus.openai.azure.com/"
 AZURE_OPENAI_DEPLOYMENT="gpt-4o-mini"
 AZURE_OPENAI_API_VERSION="2023-05-15"

--- a/tools/run-python-example2.ps1
+++ b/tools/run-python-example2.ps1
@@ -16,4 +16,4 @@ Set-Location "examples/python/python-02-simple-chatbot"
 
 # Run the commands
 uv sync
-uv run start-semantic-workbench-assistant assistant.chat:app --port 3002
+uv run start-semantic-workbench-assistant assistant.chat:app

--- a/tools/run-python-example2.sh
+++ b/tools/run-python-example2.sh
@@ -8,4 +8,4 @@ cd $ROOT
 cd examples/python/python-02-simple-chatbot
 
 uv sync
-uv run start-semantic-workbench-assistant assistant.chat:app --port 3002
+uv run start-semantic-workbench-assistant assistant.chat:app

--- a/workbench-app/.vscode/launch.json
+++ b/workbench-app/.vscode/launch.json
@@ -1,15 +1,15 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "app: semantic-workbench-app",
-      "cwd": "${workspaceFolder}",
-      "skipFiles": ["<node_internals>/**"],
-      "console": "integratedTerminal",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"]
-    }
-  ]
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "app: semantic-workbench-app",
+            "cwd": "${workspaceFolder}",
+            "skipFiles": ["<node_internals>/**"],
+            "console": "integratedTerminal",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "dev"]
+        }
+    ]
 }

--- a/workbench-app/package.json
+++ b/workbench-app/package.json
@@ -9,7 +9,7 @@
         "depcheck": "depcheck --ignores=\"@types/*,ts-prune,typescript,vite\" --ignore-dirs=\".vscode,.vs,.git,node_modules\" --skip-missing",
         "dev": "vite",
         "find-deadcode": "node ./tools/filtered-ts-prune.cjs",
-        "format": "prettier --write .",
+        "format": "prettier --write src",
         "lint": "eslint src --fix",
         "prettify": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,scss,css,html,svg}\"",
         "preview": "vite preview",

--- a/workbench-app/src/components/App/AppFooter.tsx
+++ b/workbench-app/src/components/App/AppFooter.tsx
@@ -39,10 +39,7 @@ export const AppFooter: React.FC = () => {
                 Trademarks
             </Link>{' '}
             |{' '}
-            <Link
-                href="https://github.com/microsoft/semanticworkbench"
-                target="_blank"
-            >
+            <Link href="https://github.com/microsoft/semanticworkbench" target="_blank">
                 @GitHub
             </Link>{' '}
             | <Caption1>© Microsoft 2024</Caption1>

--- a/workbench-app/src/libs/WorkbenchEventSource.ts
+++ b/workbench-app/src/libs/WorkbenchEventSource.ts
@@ -146,7 +146,7 @@ export class WorkbenchEventSource {
                 signal: abortSignal,
                 openWhenHidden: true,
                 headers: {
-                    'Authorization': `Bearer ${accessToken}`,
+                    Authorization: `Bearer ${accessToken}`,
                     'X-OpenIdToken': idToken,
                 },
                 onmessage(event: EventSourceMessage) {

--- a/workbench-service/semantic_workbench_service/config.py
+++ b/workbench-service/semantic_workbench_service/config.py
@@ -29,7 +29,7 @@ class AuthSettings(BaseSettings):
 class WebServiceSettings(BaseSettings):
     protocol: str = "http"
     hostname: str = "127.0.0.1"
-    port: int | None = 3000
+    port: int = 3000
 
     assistant_api_key: ApiKeySettings = ApiKeySettings()
 

--- a/workbench-service/semantic_workbench_service/start.py
+++ b/workbench-service/semantic_workbench_service/start.py
@@ -42,7 +42,12 @@ def main():
 
     logger.info("Starting workbench service ...")
     app = create_app()
-    uvicorn.run(app, host=args.host, port=args.port, log_config={"version": 1, "disable_existing_loggers": False})
+    uvicorn.run(
+        app,
+        host=settings.service.hostname,
+        port=settings.service.port,
+        log_config={"version": 1, "disable_existing_loggers": False},
+    )
 
 
 if __name__ == "__main__":

--- a/workbench-service/tests/conftest.py
+++ b/workbench-service/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import pathlib
 import tempfile
 import uuid
@@ -49,19 +50,29 @@ def test_user_2(monkeypatch: pytest.MonkeyPatch) -> MockUser:
     return create_test_user(monkeypatch)
 
 
+def env_var(name: str) -> str | None:
+    if name in os.environ:
+        return os.environ[name]
+    dotenv_path = dotenv.find_dotenv(usecwd=True)
+    if not dotenv_path:
+        return None
+    dotenv_values = dotenv.dotenv_values(dotenv_path)
+    return dotenv_values.get(name)
+
+
 def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         "--echosql",
         action="store_true",
         help="echo db sql statements",
-        default=(dotenv.dotenv_values().get("WORKBENCH_PYTEST_ECHOSQL") or "").lower() in ["true", "1"],
+        default=(env_var("WORKBENCH_PYTEST_ECHOSQL") or "").lower() in ["true", "1"],
     )
     parser.addoption(
         "--dbtype",
         action="store",
         help="database type",
         choices=["sqlite", "postgresql"],
-        default=dotenv.dotenv_values().get("WORKBENCH_PYTEST_DBTYPE") or "sqlite",
+        default=env_var("WORKBENCH_PYTEST_DBTYPE") or "sqlite",
     )
 
 


### PR DESCRIPTION
And shows an indicator if the config is invalid.

Additionally:
- improves the openai-client config models to improve validation of endpoint fields
- return errors list on /config for other clients who don't want to validate on their own
- simplifies assistant launch by picking random port
  - now that assistants advertise their callback URL to the workbench, they can use a random available port at startup.
  - which means we don't have to pick a port for each assistant when we start them, or make sure that none of their launch configurations conflict
  - this highlighted a bug in the workbench-service that wasn't re-creating the client when the URL changed - this also fixes that bug