### PR TITLE
Disable attachments when no assistants support it

### DIFF
--- a/assistants/prospector-assistant/assistant/chat.py
+++ b/assistants/prospector-assistant/assistant/chat.py
@@ -25,6 +25,7 @@ from semantic_workbench_api_model.workbench_model import (
 )
 from semantic_workbench_assistant.assistant_app import (
     AssistantApp,
+    AssistantCapability,
     BaseModelAssistantConfig,
     ContentSafety,
     ContentSafetyEvaluator,
@@ -71,6 +72,10 @@ assistant = AssistantApp(
     assistant_service_id=service_id,
     assistant_service_name=service_name,
     assistant_service_description=service_description,
+    capabilities={
+        AssistantCapability.supports_conversation_messages_chat,
+        AssistantCapability.supports_conversation_messages_command,
+    },
     config_provider=assistant_config.provider,
     content_interceptor=content_safety,
     inspector_state_providers={
@@ -425,7 +430,7 @@ async def respond_to_conversation(
                 logger.exception(f"exception occurred calling openai chat completion: {e}")
                 content = (
                     "An error occurred while calling the OpenAI API. Is it configured correctly?"
-                    "View the debug inspector for more information."
+                    " View the debug inspector for more information."
                 )
                 deepmerge.always_merger.merge(
                     metadata,
@@ -480,7 +485,7 @@ async def respond_to_conversation(
                 logger.exception(f"exception occurred calling openai chat completion: {e}")
                 content = (
                     "An error occurred while calling the OpenAI API. Is it configured correctly?"
-                    "View the debug inspector for more information."
+                    " View the debug inspector for more information."
                 )
                 deepmerge.always_merger.merge(
                     metadata,

--- a/assistants/prospector-assistant/assistant/chat.py
+++ b/assistants/prospector-assistant/assistant/chat.py
@@ -345,6 +345,9 @@ async def respond_to_conversation(
     content: str | None = None
     completion_total_tokens: int | None = None
 
+    # set default response message type
+    message_type = MessageType.chat
+
     # TODO: DRY up this code by moving the OpenAI API call to a shared method and calling it from both branches
     # use structured response support to create or update artifacts, if artifacts are enabled
     if config.agents_config.artifact_agent.enabled:
@@ -432,6 +435,7 @@ async def respond_to_conversation(
                     "An error occurred while calling the OpenAI API. Is it configured correctly?"
                     " View the debug inspector for more information."
                 )
+                message_type = MessageType.notice
                 deepmerge.always_merger.merge(
                     metadata,
                     {
@@ -487,6 +491,7 @@ async def respond_to_conversation(
                     "An error occurred while calling the OpenAI API. Is it configured correctly?"
                     " View the debug inspector for more information."
                 )
+                message_type = MessageType.notice
                 deepmerge.always_merger.merge(
                     metadata,
                     {
@@ -501,9 +506,6 @@ async def respond_to_conversation(
                         }
                     },
                 )
-
-    # set the message type based on the content
-    message_type = MessageType.chat
 
     if content:
         # strip out the username from the response

--- a/assistants/skill-assistant/assistant/skill_assistant.py
+++ b/assistants/skill-assistant/assistant/skill_assistant.py
@@ -19,6 +19,7 @@ from semantic_workbench_api_model.workbench_model import (
 )
 from semantic_workbench_assistant.assistant_app import (
     AssistantApp,
+    AssistantCapability,
     BaseModelAssistantConfig,
     ContentSafety,
     ContentSafetyEvaluator,
@@ -61,6 +62,10 @@ assistant = AssistantApp(
     assistant_service_id=service_id,
     assistant_service_name=service_name,
     assistant_service_description=service_description,
+    capabilities={
+        AssistantCapability.supports_conversation_messages_chat,
+        AssistantCapability.supports_conversation_messages_command,
+    },
     config_provider=assistant_config.provider,
     content_interceptor=content_safety,
 )

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
@@ -14,6 +14,7 @@ from semantic_workbench_api_model.workbench_model import (
 )
 from semantic_workbench_assistant.assistant_app import (
     AssistantApp,
+    AssistantCapability,
     ConversationContext,
     storage_directory_for_context,
 )
@@ -89,6 +90,10 @@ class AttachmentsExtension:
         """
 
         self._error_handler = error_handler
+
+        # add the 'supports_conversation_files' capability to the assistant, to indicate that this
+        # assistant supports files in the conversation
+        assistant.add_capability(AssistantCapability.supports_conversation_files)
 
         # listen for file events for to pro-actively update and delete attachments
 

--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/assistant_model.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/assistant_model.py
@@ -56,6 +56,7 @@ class ServiceInfoModel(BaseModel):
     name: str
     description: str
     default_config: ConfigResponseModel
+    metadata: dict[str, Any] = {}
 
 
 class ConversationPutRequestModel(BaseModel):

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/__init__.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/__init__.py
@@ -11,6 +11,7 @@ from .context import AssistantContext, ConversationContext, storage_directory_fo
 from .error import BadRequestError, ConflictError, NotFoundError
 from .export_import import FileStorageAssistantDataExporter, FileStorageConversationDataExporter
 from .protocol import (
+    AssistantCapability,
     AssistantConfigDataModel,
     AssistantConfigProvider,
     AssistantConversationInspectorStateDataModel,
@@ -20,6 +21,7 @@ from .protocol import (
 __all__ = [
     "AlwaysWarnContentSafetyEvaluator",
     "AssistantApp",
+    "AssistantCapability",
     "AssistantConfigProvider",
     "AssistantConfigDataModel",
     "AssistantContext",

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/assistant.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/assistant.py
@@ -1,7 +1,9 @@
 from typing import (
+    Any,
     Mapping,
 )
 
+import deepmerge
 from fastapi import FastAPI
 from pydantic import BaseModel, ConfigDict
 
@@ -11,6 +13,7 @@ from .config import BaseModelAssistantConfig
 from .content_safety import AlwaysWarnContentSafetyEvaluator, ContentSafety
 from .export_import import FileStorageAssistantDataExporter, FileStorageConversationDataExporter
 from .protocol import (
+    AssistantCapability,
     AssistantConfigProvider,
     AssistantConversationInspectorStateProvider,
     AssistantDataExporter,
@@ -31,6 +34,8 @@ class AssistantApp:
         assistant_service_id: str,
         assistant_service_name: str,
         assistant_service_description: str,
+        assistant_service_metadata: dict[str, Any] = {},
+        capabilities: set[AssistantCapability] = {AssistantCapability.supports_conversation_messages_chat},
         config_provider: AssistantConfigProvider = BaseModelAssistantConfig(EmptyConfigModel).provider,
         data_exporter: AssistantDataExporter = FileStorageAssistantDataExporter(),
         conversation_data_exporter: ConversationDataExporter = FileStorageConversationDataExporter(),
@@ -40,6 +45,8 @@ class AssistantApp:
         self.assistant_service_id = assistant_service_id
         self.assistant_service_name = assistant_service_name
         self.assistant_service_description = assistant_service_description
+        self._assistant_service_metadata = assistant_service_metadata
+        self._capabilities = capabilities
 
         self.config_provider = config_provider
         self.data_exporter = data_exporter
@@ -49,6 +56,13 @@ class AssistantApp:
 
         self.events = Events()
 
+    @property
+    def assistant_service_metadata(self) -> dict[str, Any]:
+        return deepmerge.always_merger.merge(
+            self._assistant_service_metadata,
+            {"capabilities": {capability: True for capability in self._capabilities}},
+        )
+
     def add_inspector_state_provider(
         self,
         state_id: str,
@@ -57,6 +71,9 @@ class AssistantApp:
         if state_id in self.inspector_state_providers:
             raise ValueError(f"Inspector state provider with id {state_id} already exists")
         self.inspector_state_providers[state_id] = provider
+
+    def add_capability(self, capability: AssistantCapability) -> None:
+        self._capabilities.add(capability)
 
     def fastapi_app(self) -> FastAPI:
         return create_app(

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/protocol.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/protocol.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import (
     IO,
     Any,
@@ -240,6 +241,9 @@ class AssistantAppProtocol(Protocol):
     def assistant_service_description(self) -> str: ...
 
     @property
+    def assistant_service_metadata(self) -> dict[str, Any]: ...
+
+    @property
     def config_provider(self) -> AssistantConfigProvider: ...
 
     @property
@@ -259,3 +263,22 @@ class AssistantAppProtocol(Protocol):
         state_id: str,
         provider: AssistantConversationInspectorStateProvider,
     ) -> None: ...
+
+
+class AssistantCapability(StrEnum):
+    """Enum for the capabilities of the assistant."""
+
+    supports_conversation_files = "supports_conversation_files"
+    """Advertise support for awareness of files in the conversation."""
+
+    supports_conversation_messages_directed_at = "supports_conversation_messages_directed_at"
+    """
+    Advertise support for the directed_at attribute in message metadata, and only respond to
+    messages that are directed to the assistant.
+    """
+
+    supports_conversation_messages_chat = "supports_conversation_messages_chat"
+    """Advertise support for responding to messages of type 'chat'."""
+
+    supports_conversation_messages_command = "supports_conversation_messages_command"
+    """Advertise support for responding to messages of type 'command'."""

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
@@ -230,6 +230,7 @@ class AssistantService(FastAPIAssistantService):
                 json_schema=default_config.json_schema,
                 ui_schema=default_config.ui_schema,
             ),
+            metadata=self.assistant_app.assistant_service_metadata,
         )
 
     @translate_assistant_errors

--- a/workbench-app/src/components/Conversations/InputOptionsControl.tsx
+++ b/workbench-app/src/components/Conversations/InputOptionsControl.tsx
@@ -37,6 +37,12 @@ export const InputOptionsControl: React.FC<InputOptionsControlProps> = (props) =
     const [directedAtId, setDirectedAtId] = React.useState<string>(directedAtDefaultKey);
     const [directedAtName, setDirectedAtName] = React.useState<string>(directedAtDefaultValue);
 
+    const assistantParticipants =
+        participants
+            ?.filter((participant) => participant.role === 'assistant')
+            .filter((participant) => participant.active)
+            .toSorted((a, b) => a.name.localeCompare(b.name)) ?? [];
+
     const handleDirectedToChange = (participantId?: string, participantName?: string) => {
         setDirectedAtId(participantId ?? directedAtDefaultKey);
         setDirectedAtName(participantName ?? directedAtDefaultValue);
@@ -51,11 +57,7 @@ export const InputOptionsControl: React.FC<InputOptionsControlProps> = (props) =
                 <div>Directed to:</div>
                 <div>
                     <Dropdown
-                        disabled={
-                            disabled ||
-                            participants?.filter((participant) => participant.role === 'assistant').length === 0 ||
-                            messageTypeValue !== 'Command'
-                        }
+                        disabled={disabled || assistantParticipants.length < 2 || messageTypeValue !== 'Command'}
                         className={classes.fullWidth}
                         placeholder="Select participant"
                         value={directedAtName}
@@ -65,15 +67,11 @@ export const InputOptionsControl: React.FC<InputOptionsControlProps> = (props) =
                         <Option key={directedAtDefaultKey} value={directedAtDefaultKey}>
                             {directedAtDefaultValue}
                         </Option>
-                        {participants
-                            ?.slice()
-                            .sort((a, b) => a.name.localeCompare(b.name))
-                            .filter((participant) => participant.role === 'assistant')
-                            .map((participant) => (
-                                <Option key={participant.id} value={participant.id}>
-                                    {participant.name}
-                                </Option>
-                            ))}
+                        {assistantParticipants.map((participant) => (
+                            <Option key={participant.id} value={participant.id}>
+                                {participant.name}
+                            </Option>
+                        ))}
                     </Dropdown>
                 </div>
             </div>

--- a/workbench-app/src/components/Conversations/InteractInput.tsx
+++ b/workbench-app/src/components/Conversations/InteractInput.tsx
@@ -29,6 +29,7 @@ import React from 'react';
 import { Constants } from '../../Constants';
 import useDragAndDrop from '../../libs/useDragAndDrop';
 import { useLocalUserAccount } from '../../libs/useLocalUserAccount';
+import { AssistantCapability } from '../../models/AssistantCapability';
 import { ConversationParticipant } from '../../models/ConversationParticipant';
 import { useAppDispatch, useAppSelector } from '../../redux/app/hooks';
 import { addError } from '../../redux/features/app/appSlice';
@@ -108,6 +109,7 @@ interface InteractInputProps {
     conversationId: string;
     additionalContent?: React.ReactNode;
     readOnly: boolean;
+    assistantCapabilities: Set<AssistantCapability>;
 }
 
 interface SerializedTemporaryTextNode extends SerializedTextNode {}
@@ -131,7 +133,7 @@ class TemporaryTextNode extends TextNode {
 }
 
 export const InteractInput: React.FC<InteractInputProps> = (props) => {
-    const { conversationId, additionalContent, readOnly } = props;
+    const { conversationId, additionalContent, readOnly, assistantCapabilities } = props;
     const classes = useClasses();
     const dropTargetRef = React.useRef<HTMLDivElement>(null);
     const isDraggingOverBody = useAppSelector((state) => state.app.isDraggingOverBody);
@@ -471,6 +473,8 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
 
     const disableSend = readOnly || isSubmitting || tokenCount === 0;
     const disableInputs = readOnly || isSubmitting || isListening;
+    const disableAttachments =
+        readOnly || isSubmitting || !assistantCapabilities.has(AssistantCapability.SupportsConversationFiles);
 
     return (
         <div className={classes.root}>
@@ -537,7 +541,7 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
                                         />
                                         <Button
                                             appearance="transparent"
-                                            disabled={disableInputs}
+                                            disabled={disableAttachments}
                                             icon={<Attach20Regular />}
                                             onClick={onAttachment}
                                         />

--- a/workbench-app/src/components/Conversations/InteractInput.tsx
+++ b/workbench-app/src/components/Conversations/InteractInput.tsx
@@ -476,6 +476,15 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
     const disableAttachments =
         readOnly || isSubmitting || !assistantCapabilities.has(AssistantCapability.SupportsConversationFiles);
 
+    const tokenCounts = `${tokenCount} token${tokenCount !== 1 ? 's' : ''}`;
+    const attachmentCount = disableAttachments
+        ? ''
+        : `${attachmentFiles.size} attachments (max ${Constants.app.maxFileAttachmentsPerMessage})`;
+    const inputCounts = [tokenCounts, attachmentCount].filter((count) => count !== '').join(' | ');
+    const attachFilesButtonTitle = disableAttachments
+        ? 'Attachments are not supported by the assistants in this conversation'
+        : 'Attach files';
+
     return (
         <div className={classes.root}>
             {readOnly ? (
@@ -516,12 +525,7 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
                             charactersRemainingMessage={(charactersRemaining) =>
                                 `${charactersRemaining} characters remaining`
                             }
-                            count={
-                                <span>
-                                    {tokenCount} tokens | {attachmentFiles.size} attachments (max{' '}
-                                    {Constants.app.maxFileAttachmentsPerMessage})
-                                </span>
-                            }
+                            count={<span>{inputCounts}</span>}
                             disabled={readOnly}
                             placeholderValue="Ask a question or request assistance or type / to enter a command."
                             customNodes={[ChatInputTokenNode, ChatInputEntityNode, LineBreakNode, TemporaryTextNode]}
@@ -541,6 +545,7 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
                                         />
                                         <Button
                                             appearance="transparent"
+                                            title={attachFilesButtonTitle}
                                             disabled={disableAttachments}
                                             icon={<Attach20Regular />}
                                             onClick={onAttachment}

--- a/workbench-app/src/components/Workflows/WorkflowConversation.tsx
+++ b/workbench-app/src/components/Workflows/WorkflowConversation.tsx
@@ -17,6 +17,7 @@ import { Constants } from '../../Constants';
 import { InteractHistory } from '../../components/Conversations/InteractHistory';
 import { InteractInput } from '../../components/Conversations/InteractInput';
 import { WorkbenchEventSource } from '../../libs/WorkbenchEventSource';
+import { useGetAssistantCapabilitiesSet } from '../../libs/useAssistantCapabilities';
 import { useEnvironment } from '../../libs/useEnvironment';
 import { useInteractCanvasController } from '../../libs/useInteractCanvasController';
 import { useSiteUtility } from '../../libs/useSiteUtility';
@@ -151,6 +152,7 @@ export const WorkflowConversation: React.FC<WorkflowConversationProps> = (props)
         isLoading: isLoadingParticipants,
         error: participantsError,
     } = useGetConversationParticipantsQuery(conversationId, { refetchOnMountOrArgChange: true });
+    const assistantCapabilities = useGetAssistantCapabilitiesSet(workflowRunAssistants ?? []);
 
     const [isResizing, setIsResizing] = React.useState(false);
     const siteUtility = useSiteUtility();
@@ -238,6 +240,7 @@ export const WorkflowConversation: React.FC<WorkflowConversationProps> = (props)
         isLoadingWorkflowRunAssistants ||
         isLoadingConversation ||
         isLoadingParticipants ||
+        !assistantCapabilities ||
         !conversation ||
         !participants ||
         !workflowRunAssistants
@@ -272,6 +275,7 @@ export const WorkflowConversation: React.FC<WorkflowConversationProps> = (props)
                     <InteractInput
                         readOnly={readOnly}
                         conversationId={conversation.id}
+                        assistantCapabilities={assistantCapabilities}
                         additionalContent={
                             <>
                                 <MessageBar intent="warning" layout="multiline">

--- a/workbench-app/src/libs/useAssistantCapabilities.ts
+++ b/workbench-app/src/libs/useAssistantCapabilities.ts
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Assistant } from '../models/Assistant';
+import { AssistantCapability } from '../models/AssistantCapability';
+import { useWorkbenchService } from './useWorkbenchService';
+
+export function useGetAssistantCapabilitiesSet(assistants: Assistant[]) {
+    const [assistantCapabilities, setAssistantCapabilities] = React.useState<Set<AssistantCapability> | undefined>();
+    const workbenchService = useWorkbenchService();
+
+    // Build a memo-ized set of all capabilities to be used as a default for assistants that do not
+    // specify capabilities
+    const allCapabilities = React.useMemo(
+        () =>
+            Object.entries(AssistantCapability).reduce((acc, [_, capability]) => {
+                acc.add(capability);
+                return acc;
+            }, new Set<AssistantCapability>()),
+        [],
+    );
+
+    // Load the capabilities for all assistants and update the state with the result
+    React.useEffect(() => {
+        let ignore = false;
+
+        loadCapabilities();
+
+        return () => {
+            ignore = true;
+        };
+
+        async function loadCapabilities() {
+            if (assistants.length === 0) {
+                if (ignore) {
+                    return;
+                }
+                // only update the state if the capabilities have changed
+                if (!assistantCapabilities || allCapabilities.symmetricDifference(assistantCapabilities).size > 0) {
+                    setAssistantCapabilities(allCapabilities);
+                }
+                return;
+            }
+            // Get the service info for each assistant
+            const serviceInfos = (
+                await Promise.all(
+                    assistants.map(async (assistant) => {
+                        return await workbenchService.getAssistantServiceInfoAsync(assistant.assistantServiceId);
+                    }),
+                )
+            ).filter((info) => info !== undefined);
+
+            // Combine all capabilities from all assistants into a single set
+            const capabilities = serviceInfos.reduce<Set<AssistantCapability>>((acc, info) => {
+                const metadataCapabilities = info.metadata?.capabilities;
+
+                // If there are no capabilities specified at all, default to all capabilities
+                if (metadataCapabilities === undefined || Object.keys(metadataCapabilities).length === 0) {
+                    acc.union(allCapabilities);
+                    return acc;
+                }
+
+                const capabilitiesSet = new Set(
+                    Object.keys(metadataCapabilities)
+                        .filter((key) => metadataCapabilities[key])
+                        .map((key) => key as AssistantCapability),
+                );
+                acc = acc.union(capabilitiesSet);
+                return acc;
+            }, new Set<AssistantCapability>());
+
+            if (ignore) {
+                return;
+            }
+
+            // only update the state if the capabilities have changed
+            if (!assistantCapabilities || capabilities.symmetricDifference(assistantCapabilities).size > 0) {
+                setAssistantCapabilities(capabilities);
+            }
+        }
+    }, [allCapabilities, assistantCapabilities, assistants, workbenchService]);
+
+    return assistantCapabilities;
+}

--- a/workbench-app/src/libs/useWorkbenchService.ts
+++ b/workbench-app/src/libs/useWorkbenchService.ts
@@ -129,7 +129,7 @@ export const useWorkbenchService = () => {
     const getAzureSpeechTokenAsync = async (): Promise<{ token: string; region: string }> => {
         const response = await tryFetchAsync('Get Azure Speech token', `${environment.url}/azure-speech/token`);
         const json = await response.json();
-        return { token: json.token, region: json.region };
+        return { token: json.token ?? '', region: json.region ?? '' };
     };
 
     const downloadConversationFileAsync = async (

--- a/workbench-app/src/models/AssistantCapability.ts
+++ b/workbench-app/src/models/AssistantCapability.ts
@@ -1,0 +1,6 @@
+export enum AssistantCapability {
+    SupportsConversationFiles = 'supports_conversation_files',
+    SupportsConversationMessagesDirectedAt = 'supports_conversation_messages_directed_at',
+    SupportsConversationMessagesChat = 'supports_conversation_messages_chat',
+    SupportsConversationMessagesCommand = 'supports_conversation_messages_command',
+}

--- a/workbench-app/src/models/AssistantServiceInfo.ts
+++ b/workbench-app/src/models/AssistantServiceInfo.ts
@@ -4,4 +4,7 @@ import { Config } from './Config';
 
 export interface AssistantServiceInfo {
     defaultConfig: Config;
+    metadata?: {
+        [key: string]: any;
+    };
 }

--- a/workbench-app/src/routes/Interact.tsx
+++ b/workbench-app/src/routes/Interact.tsx
@@ -13,7 +13,9 @@ import { InteractHistory } from '../components/Conversations/InteractHistory';
 import { InteractInput } from '../components/Conversations/InteractInput';
 import { useLocalUserAccount } from '../libs/useLocalUserAccount';
 import { useSiteUtility } from '../libs/useSiteUtility';
+import { useWorkbenchService } from '../libs/useWorkbenchService';
 import { Assistant } from '../models/Assistant';
+import { AssistantCapability } from '../models/AssistantCapability';
 import {
     useGetAssistantsInConversationQuery,
     useGetConversationFilesQuery,
@@ -99,6 +101,10 @@ export const Interact: React.FC = () => {
     } = useGetConversationFilesQuery(conversationId);
     const [updateConversation] = useUpdateConversationMutation();
     const { getUserId } = useLocalUserAccount();
+    const [assistantCapabilities, setAssistantCapabilities] = React.useState<Set<AssistantCapability> | undefined>(
+        undefined,
+    );
+    const workbenchService = useWorkbenchService();
 
     const siteUtility = useSiteUtility();
 
@@ -143,6 +149,85 @@ export const Interact: React.FC = () => {
         }
     }, [conversation, conversationParticipants, siteUtility]);
 
+    // Build a memo-ized set of all capabilities to be used as a default for assistants that do not
+    // specify capabilities
+    const allCapabilities = React.useMemo(
+        () =>
+            Object.entries(AssistantCapability).reduce((acc, [_, capability]) => {
+                acc.add(capability);
+                return acc;
+            }, new Set<AssistantCapability>()),
+        [],
+    );
+
+    // Load the capabilities for all assistants and update the state with the result
+    React.useEffect(() => {
+        if (isLoadingAssistants || !assistants) {
+            return;
+        }
+
+        let ignore = false;
+
+        loadCapabilities();
+
+        return () => {
+            ignore = true;
+        };
+
+        async function loadCapabilities() {
+            if (isLoadingAssistants || !assistants) {
+                return;
+            }
+
+            if (assistants.length === 0) {
+                if (ignore) {
+                    return;
+                }
+                // only update the state if the capabilities have changed
+                if (!assistantCapabilities || allCapabilities.symmetricDifference(assistantCapabilities).size > 0) {
+                    setAssistantCapabilities(allCapabilities);
+                }
+                return;
+            }
+            // Get the service info for each assistant
+            const serviceInfos = (
+                await Promise.all(
+                    assistants.map(async (assistant) => {
+                        return await workbenchService.getAssistantServiceInfoAsync(assistant.assistantServiceId);
+                    }),
+                )
+            ).filter((info) => info !== undefined);
+
+            // Combine all capabilities from all assistants into a single set
+            const capabilities = serviceInfos.reduce<Set<AssistantCapability>>((acc, info) => {
+                const metadataCapabilities = info.metadata?.capabilities;
+
+                // If there are no capabilities specified at all, default to all capabilities
+                if (metadataCapabilities === undefined || Object.keys(metadataCapabilities).length === 0) {
+                    acc.union(allCapabilities);
+                    return acc;
+                }
+
+                const capabilitiesSet = new Set(
+                    Object.keys(metadataCapabilities)
+                        .filter((key) => metadataCapabilities[key])
+                        .map((key) => key as AssistantCapability),
+                );
+                acc = acc.union(capabilitiesSet);
+                return acc;
+            }, new Set<AssistantCapability>());
+
+            if (ignore) {
+                return;
+            }
+
+            // only update the state if the capabilities have changed
+            if (!assistantCapabilities || capabilities.symmetricDifference(assistantCapabilities).size > 0) {
+                setAssistantCapabilities(capabilities);
+            }
+        }
+    }, [allCapabilities, assistantCapabilities, assistants, isLoadingAssistants, workbenchService]);
+
     const handleConversationRename = React.useCallback(
         async (id: string, newTitle: string) => {
             await updateConversation({ id, title: newTitle });
@@ -185,6 +270,7 @@ export const Interact: React.FC = () => {
         isLoadingConversationParticipants ||
         isLoadingConversationFiles ||
         !assistants ||
+        !assistantCapabilities ||
         !conversation ||
         !conversationParticipants ||
         !conversationFiles
@@ -231,7 +317,11 @@ export const Interact: React.FC = () => {
                         </div>
                     </div>
                     <div className={classes.input}>
-                        <InteractInput readOnly={readOnly} conversationId={conversationId} />
+                        <InteractInput
+                            readOnly={readOnly}
+                            conversationId={conversationId}
+                            assistantCapabilities={assistantCapabilities}
+                        />
                     </div>
                 </div>
                 <InteractCanvas

--- a/workbench-app/src/services/workbench/assistant.ts
+++ b/workbench-app/src/services/workbench/assistant.ts
@@ -16,7 +16,7 @@ export const assistantApi = workbenchApi.injectEndpoints({
         }),
         getAssistantsInConversation: builder.query<Assistant[], string>({
             query: (conversationId: string) => `/assistants?conversation_id=${conversationId}`,
-            providesTags: ['Assistant'],
+            providesTags: ['Assistant', 'Conversation'],
             transformResponse: (response: any) => response.assistants.map(transformResponseToAssistant),
         }),
         getAssistant: builder.query<Assistant, string>({
@@ -73,6 +73,7 @@ const transformResponseToAssistantServiceDescription = (response: any): Assistan
         jsonSchema: response.default_config.json_schema,
         uiSchema: response.default_config.ui_schema,
     },
+    metadata: response.metadata,
 });
 
 const transformAssistantForRequest = (assistant: Partial<Assistant>) => ({


### PR DESCRIPTION
- surface assistant "capabilities" from the assistant service info metadata
- conditionally disable the "attachment" button based on the highest common denominator (ie. if any assistant supports it, allow it)
- for assistants that declare no capabilities, assume all capabilities -