### PR TITLE
Using PORT as env in workbench app

### DIFF
--- a/workbench-app/vite.config.ts
+++ b/workbench-app/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     ],
     server: {
         https: true,
-        host: 'localhost',
+        host: '127.0.0.1',
         port: JSON.parse(process.env.PORT || '4000'),
     },
     build: {

--- a/workbench-app/vite.config.ts
+++ b/workbench-app/vite.config.ts
@@ -27,8 +27,8 @@ export default defineConfig({
     ],
     server: {
         https: true,
-        host: '127.0.0.1',
-        port: 4000,
+        host: 'localhost',
+        port: JSON.parse(process.env.PORT || '4000'),
     },
     build: {
         outDir: 'build',


### PR DESCRIPTION
This PR addresses #167 

Update server configuration to use 'localhost' as the host and dynamically assign the port number