### PR TITLE
185 python port

### DIFF
--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
@@ -92,7 +92,7 @@ def main():
         logger.info("Enabling auto-reload ...")
 
     settings.host = args.host
-    settings.port = int(os.getenv("PORT") or args.port or find_free_port(settings.host))
+    settings.port = args.port or int(os.getenv("PORT") or find_free_port(settings.host))
     settings.assistant_service_id = args.assistant_service_id
     settings.assistant_service_name = args.assistant_service_name
     settings.assistant_service_description = args.assistant_service_description

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
@@ -92,7 +92,7 @@ def main():
         logger.info("Enabling auto-reload ...")
 
     settings.host = args.host
-    settings.port = args.port or find_free_port(settings.host)
+    settings.port = int(os.getenv("PORT") or args.port or find_free_port(settings.host))
     settings.assistant_service_id = args.assistant_service_id
     settings.assistant_service_name = args.assistant_service_name
     settings.assistant_service_description = args.assistant_service_description

--- a/workbench-service/semantic_workbench_service/start.py
+++ b/workbench-service/semantic_workbench_service/start.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 
 import uvicorn
 from fastapi import FastAPI
@@ -33,7 +34,7 @@ def main():
         help="host IP to run service on",
     )
     parse_args.add_argument(
-        "--port", dest="port", type=int, default=settings.service.port, help="port to run service on"
+        "--port", dest="port", type=int, default=int(os.getenv("PORT") or settings.service.port), help="port to run service on"
     )
     args = parse_args.parse_args()
 


### PR DESCRIPTION
Closes #185 

PORT can be passed as env var for both workbench-service and python assistants

The priority order for PORT selection is:
- args
- env variable
- default value