### PR TITLE
AssistantApp events are filtered to external events

### DIFF
--- a/assistants/explorer-assistant/assistant/chat.py
+++ b/assistants/explorer-assistant/assistant/chat.py
@@ -111,10 +111,6 @@ async def on_message_created(
       - @assistant.events.conversation.message.on_created
     """
 
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
-
     # update the participant status to indicate the assistant is thinking
     async with context.set_status_for_block("thinking..."):
         config = await assistant_config.get(context.assistant)
@@ -413,7 +409,7 @@ async def respond_to_conversation(
 
         # check if the completion total tokens exceed the warning threshold
         if completion_total_tokens > token_count_for_warning:
-            content = f"{config.high_token_usage_warning.message}\n\n" f"Total tokens used: {completion_total_tokens}"
+            content = f"{config.high_token_usage_warning.message}\n\nTotal tokens used: {completion_total_tokens}"
 
             # send a notice message to the conversation that the token usage is high
             await context.send_messages(

--- a/assistants/guided-conversation-assistant/assistant/chat.py
+++ b/assistants/guided-conversation-assistant/assistant/chat.py
@@ -118,10 +118,6 @@ async def on_message_created(
       - @assistant.events.conversation.message.on_created
     """
 
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
-
     # update the participant status to indicate the assistant is thinking
     await context.update_participant_me(UpdateParticipant(status="thinking..."))
     try:

--- a/assistants/prospector-assistant/assistant/chat.py
+++ b/assistants/prospector-assistant/assistant/chat.py
@@ -156,10 +156,6 @@ async def on_chat_message_created(
       - @assistant.events.conversation.message.on_created
     """
 
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
-
     # update the participant status to indicate the assistant is thinking
     async with context.set_status_for_block("thinking..."):
         config = await assistant_config.get(context.assistant)

--- a/assistants/skill-assistant/assistant/skill_assistant.py
+++ b/assistants/skill-assistant/assistant/skill_assistant.py
@@ -102,10 +102,6 @@ async def on_message_created(
       - @assistant.events.conversation.message.on_created
     """
 
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
-
     # pass the message to the core response logic
     await respond_to_conversation(context, event, message)
 
@@ -117,10 +113,6 @@ async def on_command_message_created(
     """
     Handle the event triggered when a new command message is created in the conversation.
     """
-
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
 
     # pass the message to the core response logic
     await respond_to_conversation(context, event, message)

--- a/examples/python/python-02-simple-chatbot/assistant/chat.py
+++ b/examples/python/python-02-simple-chatbot/assistant/chat.py
@@ -126,9 +126,6 @@ async def on_message_created(
     - To handle all message types, you can use the root event handler for all message types:
       - @assistant.events.conversation.message.on_created
     """
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
 
     # update the participant status to indicate the assistant is thinking
     await context.update_participant_me(UpdateParticipant(status="thinking..."))

--- a/examples/python/python-03-multimodel-chatbot/assistant/chat.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/chat.py
@@ -124,9 +124,6 @@ async def on_message_created(
     - To handle all message types, you can use the root event handler for all message types:
       - @assistant.events.conversation.message.on_created
     """
-    # ignore messages from this assistant
-    if message.sender.participant_id == context.assistant.id:
-        return
 
     # update the participant status to indicate the assistant is thinking
     await context.update_participant_me(UpdateParticipant(status="thinking..."))

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/service.py
@@ -135,12 +135,12 @@ class AssistantService(FastAPIAssistantService):
 
     @asynccontextmanager
     async def lifespan(self) -> AsyncIterator[None]:
-        await self.assistant_app.events._on_service_start_handlers()
+        await self.assistant_app.events._on_service_start_handlers(True)
 
         try:
             yield
         finally:
-            await self.assistant_app.events._on_service_shutdown_handlers()
+            await self.assistant_app.events._on_service_shutdown_handlers(True)
 
             for task in self._conversation_event_tasks:
                 task.cancel()
@@ -259,9 +259,9 @@ class AssistantService(FastAPIAssistantService):
 
         assistant_context = require_found(self.get_assistant_context(assistant_id))
         if is_new:
-            await self.assistant_app.events.assistant._on_created_handlers(assistant_context)
+            await self.assistant_app.events.assistant._on_created_handlers(True, assistant_context)
         else:
-            await self.assistant_app.events.assistant._on_updated_handlers(assistant_context)
+            await self.assistant_app.events.assistant._on_updated_handlers(True, assistant_context)
 
         if from_export is not None:
             await self.assistant_app.data_exporter.import_(assistant_context, from_export)
@@ -304,7 +304,7 @@ class AssistantService(FastAPIAssistantService):
         states.assistants.pop(assistant_id, None)
         self.write_assistant_states(states)
 
-        await self.assistant_app.events.assistant._on_deleted_handlers(assistant_context)
+        await self.assistant_app.events.assistant._on_deleted_handlers(True, assistant_context)
 
     @translate_assistant_errors
     async def get_config(self, assistant_id: str) -> assistant_model.ConfigResponseModel:
@@ -352,9 +352,9 @@ class AssistantService(FastAPIAssistantService):
         conversation_context = require_found(self.get_conversation_context(assistant_id, conversation_id))
 
         if is_new:
-            await self.assistant_app.events.conversation._on_created_handlers(conversation_context)
+            await self.assistant_app.events.conversation._on_created_handlers(True, conversation_context)
         else:
-            await self.assistant_app.events.conversation._on_updated_handlers(conversation_context)
+            await self.assistant_app.events.conversation._on_updated_handlers(True, conversation_context)
 
         if from_export is not None:
             await self.assistant_app.conversation_data_exporter.import_(conversation_context, from_export)
@@ -391,7 +391,7 @@ class AssistantService(FastAPIAssistantService):
             return
         self.write_assistant_states(states)
 
-        await self.assistant_app.events.conversation._on_deleted_handlers(conversation_context)
+        await self.assistant_app.events.conversation._on_deleted_handlers(True, conversation_context)
 
     async def _get_or_create_queue(self, assistant_id: str, conversation_id: str) -> asyncio.Queue[_Event]:
         key = (assistant_id, conversation_id)
@@ -487,17 +487,18 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid message event data")
                     return
 
-                type_specific_events = getattr(
-                    self.assistant_app.events.conversation.message, str(message.message_type).replace("-", "_")
-                )
+                event_originated_externally = message.sender.participant_id != conversation_context.assistant.id
+
                 async with asyncio.TaskGroup() as tg:
                     tg.create_task(
                         self.assistant_app.events.conversation.message._on_created_handlers(
-                            conversation_context, updated_event, message
+                            event_originated_externally, conversation_context, updated_event, message
                         )
                     )
                     tg.create_task(
-                        type_specific_events._on_created_handlers(conversation_context, updated_event, message)
+                        self.assistant_app.events.conversation.message[message.message_type]._on_created_handlers(
+                            event_originated_externally, conversation_context, updated_event, message
+                        )
                     )
 
             case workbench_model.ConversationEventType.message_deleted:
@@ -507,17 +508,18 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid message event data")
                     return
 
-                type_specific_events = getattr(
-                    self.assistant_app.events.conversation.message, str(message.message_type).replace("-", "_")
-                )
+                event_originated_externally = message.sender.participant_id != conversation_context.assistant.id
+
                 async with asyncio.TaskGroup() as tg:
                     tg.create_task(
                         self.assistant_app.events.conversation.message._on_deleted_handlers(
-                            conversation_context, updated_event, message
+                            event_originated_externally, conversation_context, updated_event, message
                         )
                     )
                     tg.create_task(
-                        type_specific_events._on_deleted_handlers(conversation_context, updated_event, message)
+                        self.assistant_app.events.conversation.message[message.message_type]._on_deleted_handlers(
+                            event_originated_externally, conversation_context, updated_event, message
+                        )
                     )
 
             case workbench_model.ConversationEventType.participant_created:
@@ -529,8 +531,9 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid participant event data")
                     return
 
+                event_originated_externally = participant.id != conversation_context.assistant.id
                 await self.assistant_app.events.conversation.participant._on_created_handlers(
-                    conversation_context, updated_event, participant
+                    event_originated_externally, conversation_context, updated_event, participant
                 )
 
             case workbench_model.ConversationEventType.participant_updated:
@@ -542,8 +545,9 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid participant event data")
                     return
 
+                event_originated_externally = participant.id != conversation_context.assistant.id
                 await self.assistant_app.events.conversation.participant._on_updated_handlers(
-                    conversation_context, updated_event, participant
+                    event_originated_externally, conversation_context, updated_event, participant
                 )
 
             case workbench_model.ConversationEventType.file_created:
@@ -553,8 +557,9 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid file event data")
                     return
 
+                event_originated_externally = file.participant_id != conversation_context.assistant.id
                 await self.assistant_app.events.conversation.file._on_created_handlers(
-                    conversation_context, updated_event, file
+                    event_originated_externally, conversation_context, updated_event, file
                 )
 
             case workbench_model.ConversationEventType.file_updated:
@@ -564,8 +569,9 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid file event data")
                     return
 
+                event_originated_externally = file.participant_id != conversation_context.assistant.id
                 await self.assistant_app.events.conversation.file._on_updated_handlers(
-                    conversation_context, updated_event, file
+                    event_originated_externally, conversation_context, updated_event, file
                 )
 
             case workbench_model.ConversationEventType.file_deleted:
@@ -575,8 +581,9 @@ class AssistantService(FastAPIAssistantService):
                     logging.exception("invalid file event data")
                     return
 
+                event_originated_externally = file.participant_id != conversation_context.assistant.id
                 await self.assistant_app.events.conversation.file._on_deleted_handlers(
-                    conversation_context, updated_event, file
+                    event_originated_externally, conversation_context, updated_event, file
                 )
 
     @translate_assistant_errors


### PR DESCRIPTION
By default (ie. events not generated by this assistant instance)

The decorator accepts an include parameter which can be set to "all" to
receive all events, even those originating from this assistant instance