### PR TITLE
Simplify `uv run`s in docs

### DIFF
--- a/.github/workflows/workbench-service.yml
+++ b/.github/workflows/workbench-service.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install package
-        run: uv sync
-
       - name: pytest
         run: uv run pytest --dbtype=${{ matrix.dbtype }}
 

--- a/assistants/explorer-assistant/README.md
+++ b/assistants/explorer-assistant/README.md
@@ -51,8 +51,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/assistants/guided-conversation-assistant/README.md
+++ b/assistants/guided-conversation-assistant/README.md
@@ -51,8 +51,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/assistants/prospector-assistant/README.md
+++ b/assistants/prospector-assistant/README.md
@@ -51,8 +51,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/assistants/skill-assistant/README.md
+++ b/assistants/skill-assistant/README.md
@@ -68,8 +68,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/examples/python/python-01-echo-bot/README.md
+++ b/examples/python/python-01-echo-bot/README.md
@@ -35,8 +35,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/examples/python/python-02-simple-chatbot/README.md
+++ b/examples/python/python-02-simple-chatbot/README.md
@@ -52,8 +52,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/examples/python/python-03-multimodel-chatbot/README.md
+++ b/examples/python/python-03-multimodel-chatbot/README.md
@@ -51,8 +51,6 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv sync
-
 uv run start-semantic-workbench-assistant assistant.chat:app
 ```
 

--- a/tools/run-python-example1.sh
+++ b/tools/run-python-example1.sh
@@ -7,5 +7,4 @@ cd $ROOT
 
 cd examples/python/python-01-echo-bot
 
-uv sync 
 uv run start-semantic-workbench-assistant assistant.chat:app

--- a/tools/run-python-example2.ps1
+++ b/tools/run-python-example2.ps1
@@ -15,5 +15,4 @@ Set-Location $root
 Set-Location "examples/python/python-02-simple-chatbot"
 
 # Run the commands
-uv sync
 uv run start-semantic-workbench-assistant assistant.chat:app

--- a/tools/run-python-example2.sh
+++ b/tools/run-python-example2.sh
@@ -7,5 +7,4 @@ cd $ROOT
 
 cd examples/python/python-02-simple-chatbot
 
-uv sync
 uv run start-semantic-workbench-assistant assistant.chat:app

--- a/tools/run-service.ps1
+++ b/tools/run-service.ps1
@@ -17,5 +17,4 @@ Set-Location "workbench-service"
 # Note: this creates the .data folder at
 # path         ./workbench-service/.data
 # rather than  ./workbench-service/.data
-uv sync
 uv run start-semantic-workbench-service

--- a/tools/run-service.sh
+++ b/tools/run-service.sh
@@ -10,5 +10,4 @@ cd workbench-service
 # Note: this creates the .data folder at
 # path         ./workbench-service/.data
 # rather than  ./workbench-service/.data
-uv sync
 uv run start-semantic-workbench-service

--- a/workbench-service/README.md
+++ b/workbench-service/README.md
@@ -51,5 +51,5 @@ To run and/or debug in VS Code, View->Run, "service: semantic-workbench-service"
 In the [workbench-service](./) directory
 
 ```sh
-uv run start-semantic-workbench
+uv run start-semantic-workbench-service
 ```


### PR DESCRIPTION
The extra `uv sync` is not needed - `uv run` will do that automatically. This also fixes a typo in the service README