### PR TITLE
Simplifies start-up of assistants

### DIFF
--- a/assistants/explorer-assistant/.vscode/launch.json
+++ b/assistants/explorer-assistant/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "assistants: explorer-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/explorer-assistant/README.md
+++ b/assistants/explorer-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/explorer-assistant/README.md
+++ b/assistants/explorer-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/guided-conversation-assistant/.vscode/launch.json
+++ b/assistants/guided-conversation-assistant/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "assistants: guided-conversation-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/guided-conversation-assistant/README.md
+++ b/assistants/guided-conversation-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/guided-conversation-assistant/README.md
+++ b/assistants/guided-conversation-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/prospector-assistant/.vscode/launch.json
+++ b/assistants/prospector-assistant/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "assistants: prospector-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/prospector-assistant/README.md
+++ b/assistants/prospector-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/prospector-assistant/README.md
+++ b/assistants/prospector-assistant/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/skill-assistant/.vscode/launch.json
+++ b/assistants/skill-assistant/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "assistants: skill-assistant",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.skill_assistant:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/assistants/skill-assistant/README.md
+++ b/assistants/skill-assistant/README.md
@@ -68,7 +68,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/assistants/skill-assistant/README.md
+++ b/assistants/skill-assistant/README.md
@@ -68,7 +68,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-01-echo-bot/.vscode/launch.json
+++ b/examples/python/python-01-echo-bot/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "examples: python-01-echo-bot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/examples/python/python-01-echo-bot/README.md
+++ b/examples/python/python-01-echo-bot/README.md
@@ -35,7 +35,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-01-echo-bot/README.md
+++ b/examples/python/python-01-echo-bot/README.md
@@ -35,7 +35,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-01-echo-bot/assistant/__init__.py
+++ b/examples/python/python-01-echo-bot/assistant/__init__.py
@@ -1,0 +1,3 @@
+from .chat import app
+
+__all__ = ["app"]

--- a/examples/python/python-02-simple-chatbot/.vscode/launch.json
+++ b/examples/python/python-02-simple-chatbot/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "examples: python-02-simple-chatbot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}"
     }
   ]

--- a/examples/python/python-02-simple-chatbot/README.md
+++ b/examples/python/python-02-simple-chatbot/README.md
@@ -52,7 +52,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-02-simple-chatbot/README.md
+++ b/examples/python/python-02-simple-chatbot/README.md
@@ -52,7 +52,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-02-simple-chatbot/assistant/__init__.py
+++ b/examples/python/python-02-simple-chatbot/assistant/__init__.py
@@ -1,0 +1,3 @@
+from .chat import app
+
+__all__ = ["app"]

--- a/examples/python/python-03-multimodel-chatbot/.vscode/launch.json
+++ b/examples/python/python-03-multimodel-chatbot/.vscode/launch.json
@@ -7,7 +7,6 @@
       "name": "examples: python-03-multimodel-chatbot",
       "cwd": "${workspaceFolder}",
       "module": "semantic_workbench_assistant.start",
-      "args": ["assistant.chat:app"],
       "consoleTitle": "${workspaceFolderBasename}",
       "justMyCode": false
     }

--- a/examples/python/python-03-multimodel-chatbot/README.md
+++ b/examples/python/python-03-multimodel-chatbot/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-03-multimodel-chatbot/README.md
+++ b/examples/python/python-03-multimodel-chatbot/README.md
@@ -51,7 +51,7 @@ command line, using `uv`:
 ```
 cd <PATH TO THIS FOLDER>
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant
 ```
 
 ## Create your own assistant

--- a/examples/python/python-03-multimodel-chatbot/assistant/__init__.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/__init__.py
@@ -1,0 +1,3 @@
+from .chat import app
+
+__all__ = ["app"]

--- a/libraries/python/semantic-workbench-assistant/README.md
+++ b/libraries/python/semantic-workbench-assistant/README.md
@@ -10,5 +10,5 @@ To start the canonical assistant:
 
 ```sh
 cd workbench-service
-start-semantic-workbench-assistant semantic_workbench_assistant.canonical:app
+start-assistant semantic_workbench_assistant.canonical:app
 ```

--- a/libraries/python/semantic-workbench-assistant/pyproject.toml
+++ b/libraries/python/semantic-workbench-assistant/pyproject.toml
@@ -30,6 +30,7 @@ semantic-workbench-api-model = { path = "../semantic-workbench-api-model", edita
 
 [project.scripts]
 start-semantic-workbench-assistant = "semantic_workbench_assistant.start:main"
+start-assistant = "semantic_workbench_assistant.start:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/start.py
@@ -20,6 +20,12 @@ def main():
         description="start a FastAPI assistant service", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parse_args.add_argument(
+        "--app",
+        type=str,
+        help="assistant app to start; ex: workbench_assistant.canonical:app",
+        default=os.getenv("ASSISTANT_APP", "assistant:app"),
+    )
+    parse_args.add_argument(
         "--port",
         dest="port",
         type=int,
@@ -65,21 +71,6 @@ def main():
     parse_args.add_argument(
         "--reload", dest="reload", nargs="?", action="store", type=str, default="false", help="enable auto-reload"
     )
-
-    app = os.getenv("ASSISTANT_APP", None)
-    if app:
-        parse_args.add_argument(
-            "--app",
-            type=str,
-            help="assistant app to start; ex: workbench_assistant.canonical:app",
-            default=app,
-        )
-    else:
-        parse_args.add_argument(
-            "app",
-            type=str,
-            help="assistant app to start; ex: workbench_assistant.canonical:app",
-        )
 
     args = parse_args.parse_args()
 

--- a/tools/docker/Dockerfile.assistant
+++ b/tools/docker/Dockerfile.assistant
@@ -54,4 +54,4 @@ ENV assistant__port=3001
 
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
-CMD ["start-semantic-workbench-assistant"]
+CMD ["start-assistant"]

--- a/tools/makefiles/docker-assistant.mk
+++ b/tools/makefiles/docker-assistant.mk
@@ -27,4 +27,4 @@ docker-run-local: docker-build
 
 .PHONY: start
 start:
-	uv run start-semantic-workbench-assistant
+	uv run start-assistant

--- a/tools/makefiles/docker-assistant.mk
+++ b/tools/makefiles/docker-assistant.mk
@@ -23,3 +23,8 @@ ASSISTANT__WORKBENCH_SERVICE_URL ?= http://host.docker.internal:3000
 
 docker-run-local: docker-build
 	docker run --rm -it --add-host=host.docker.internal:host-gateway --env assistant__workbench_service_url=$(ASSISTANT__WORKBENCH_SERVICE_URL) $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
+
+
+.PHONY: start
+start:
+	uv run start-semantic-workbench-assistant

--- a/tools/run-canonical-agent.ps1
+++ b/tools/run-canonical-agent.ps1
@@ -15,4 +15,4 @@ Set-Location $root
 Set-Location "workbench-service"
 
 # Run the command
-uv run start-semantic-workbench-assistant semantic_workbench_assistant.canonical:app
+uv run start-assistant semantic_workbench_assistant.canonical:app

--- a/tools/run-canonical-agent.sh
+++ b/tools/run-canonical-agent.sh
@@ -7,4 +7,4 @@ cd $ROOT
 
 cd workbench-service
 
-uv run start-semantic-workbench-assistant semantic_workbench_assistant.canonical:app
+uv run start-assistant semantic_workbench_assistant.canonical:app

--- a/tools/run-python-example1.sh
+++ b/tools/run-python-example1.sh
@@ -7,4 +7,4 @@ cd $ROOT
 
 cd examples/python/python-01-echo-bot
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant

--- a/tools/run-python-example1.sh
+++ b/tools/run-python-example1.sh
@@ -7,4 +7,4 @@ cd $ROOT
 
 cd examples/python/python-01-echo-bot
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant

--- a/tools/run-python-example2.ps1
+++ b/tools/run-python-example2.ps1
@@ -15,4 +15,4 @@ Set-Location $root
 Set-Location "examples/python/python-02-simple-chatbot"
 
 # Run the commands
-uv run start-semantic-workbench-assistant
+uv run start-assistant

--- a/tools/run-python-example2.ps1
+++ b/tools/run-python-example2.ps1
@@ -15,4 +15,4 @@ Set-Location $root
 Set-Location "examples/python/python-02-simple-chatbot"
 
 # Run the commands
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant

--- a/tools/run-python-example2.sh
+++ b/tools/run-python-example2.sh
@@ -7,4 +7,4 @@ cd $ROOT
 
 cd examples/python/python-02-simple-chatbot
 
-uv run start-semantic-workbench-assistant
+uv run start-assistant

--- a/tools/run-python-example2.sh
+++ b/tools/run-python-example2.sh
@@ -7,4 +7,4 @@ cd $ROOT
 
 cd examples/python/python-02-simple-chatbot
 
-uv run start-semantic-workbench-assistant assistant.chat:app
+uv run start-semantic-workbench-assistant

--- a/tools/run-service.ps1
+++ b/tools/run-service.ps1
@@ -17,4 +17,4 @@ Set-Location "workbench-service"
 # Note: this creates the .data folder at
 # path         ./workbench-service/.data
 # rather than  ./workbench-service/.data
-uv run start-semantic-workbench-service
+uv run start-service

--- a/tools/run-service.sh
+++ b/tools/run-service.sh
@@ -10,4 +10,4 @@ cd workbench-service
 # Note: this creates the .data folder at
 # path         ./workbench-service/.data
 # rather than  ./workbench-service/.data
-uv run start-semantic-workbench-service
+uv run start-service

--- a/workbench-app/Makefile
+++ b/workbench-app/Makefile
@@ -22,4 +22,8 @@ format: install
 lint: install
 	pnpm run lint
 
+.PHONY: start
+start:
+	pnpm run start
+
 include $(repo_root)/tools/makefiles/shell.mk

--- a/workbench-service/Dockerfile
+++ b/workbench-service/Dockerfile
@@ -44,4 +44,4 @@ ENV workbench__service__port=3000
 
 SHELL ["/bin/bash", "-c"]
 ENTRYPOINT ["/scripts/docker-entrypoint.sh"]
-CMD ["start-semantic-workbench-service"]
+CMD ["start-service"]

--- a/workbench-service/Makefile
+++ b/workbench-service/Makefile
@@ -2,7 +2,19 @@ repo_root = $(shell git rev-parse --show-toplevel)
 
 include $(repo_root)/tools/makefiles/python.mk
 
+-include ./.env
+
+DBTYPE ?= sqlite
+
+ifeq ($(DBTYPE), postgresql)
 WORKBENCH__DB__URL ?= postgresql:///workbench
+else
+WORKBENCH__DB__URL ?= sqlite:///.data/workbench.db
+endif
+
+.PHONY: start
+start:
+	WORKBENCH__DB__URL="$(WORKBENCH__DB__URL)" uv run start-semantic-workbench-service
 
 .PHONY: alembic-upgrade-head
 alembic-upgrade-head:

--- a/workbench-service/Makefile
+++ b/workbench-service/Makefile
@@ -14,7 +14,7 @@ endif
 
 .PHONY: start
 start:
-	WORKBENCH__DB__URL="$(WORKBENCH__DB__URL)" uv run start-semantic-workbench-service
+	WORKBENCH__DB__URL="$(WORKBENCH__DB__URL)" uv run start-service
 
 .PHONY: alembic-upgrade-head
 alembic-upgrade-head:

--- a/workbench-service/README.md
+++ b/workbench-service/README.md
@@ -51,5 +51,5 @@ To run and/or debug in VS Code, View->Run, "service: semantic-workbench-service"
 In the [workbench-service](./) directory
 
 ```sh
-uv run start-semantic-workbench-service
+uv run start-service
 ```

--- a/workbench-service/pyproject.toml
+++ b/workbench-service/pyproject.toml
@@ -48,6 +48,7 @@ semantic-workbench-assistant = { path = "../libraries/python/semantic-workbench-
 
 [project.scripts]
 start-semantic-workbench-service = "semantic_workbench_service.start:main"
+start-service = "semantic_workbench_service.start:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
`start-semantic-workbench-assistant` now has default assistant app name, simplifying start-up command line, and therefore launch.json, for assistants