### PR TITLE
Add set_mode_draft_paper command and initial piping

### DIFF
--- a/assistants/prospector-assistant/assistant/agents/document/guided_conversation.py
+++ b/assistants/prospector-assistant/assistant/agents/document/guided_conversation.py
@@ -139,7 +139,10 @@ class GuidedConversationAgent:
                         next_step_name = StepName.DO_DRAFT_OUTLINE
                     elif user_decision == "draft_paper":
                         status = Status.USER_COMPLETED
-                        next_step_name = StepName.DO_FINISH
+                        next_step_name = (
+                            StepName.DP_DRAFT_CONTENT
+                        )  # problem if in draft outline mode... that is supposed to go to DO_FINISH.
+                        # coupling is now a problem.  and Need to fix the two locations for setting the branching/flow.
                     else:
                         logger.error("unknown user decision")
             else:

--- a/assistants/prospector-assistant/assistant/agents/document/status.py
+++ b/assistants/prospector-assistant/assistant/agents/document/status.py
@@ -15,3 +15,4 @@ class StepName(StrEnum):
     DO_DRAFT_OUTLINE = "step_draft_outline"
     DO_GC_GET_OUTLINE_FEEDBACK = "step_gc_get_outline_feedback"
     DO_FINISH = "step_finish"
+    DP_DRAFT_CONTENT = "step_draft_content"


### PR DESCRIPTION
- Adds a new mode: mode_draft_paper, which is turned on via a command.
- Adds a new step for mode: step_draft_paper, which comes after the prior draft_outline steps.
- Updates doc agent's gc helper code to branch for drafting a paper. 
- Only supports single creation of first "content".