### PR TITLE
workflow-lite, duplicate conversation, conversation list updates

### DIFF
--- a/libraries/python/assistant-extensions/assistant_extensions/workflows/_model.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/workflows/_model.py
@@ -4,6 +4,28 @@ from pydantic import BaseModel, Field
 from semantic_workbench_assistant.config import UISchema
 
 
+class UserMessage(BaseModel):
+    class Config:
+        json_schema_extra = {
+            "required": ["status_label", "message"],
+        }
+
+    status_label: Annotated[
+        str,
+        Field(
+            description="The status label to be displayed when the message is sent to the assistant.",
+        ),
+    ] = ""
+
+    message: Annotated[
+        str,
+        Field(
+            description="The message to be sent to the assistant.",
+        ),
+        UISchema(widget="textarea"),
+    ] = ""
+
+
 class UserProxyWorkflowDefinition(BaseModel):
     class Config:
         json_schema_extra = {
@@ -37,11 +59,10 @@ class UserProxyWorkflowDefinition(BaseModel):
         UISchema(widget="textarea"),
     ] = ""
     user_messages: Annotated[
-        list[str],
+        list[UserMessage],
         Field(
             description="A list of user messages that will be sequentially sent to the assistant during the workflow.",
         ),
-        UISchema(schema={"items": {"widget": "textarea"}}),
     ] = []
 
 

--- a/libraries/python/assistant-extensions/assistant_extensions/workflows/runners/_user_proxy.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/workflows/runners/_user_proxy.py
@@ -170,6 +170,7 @@ class UserProxyRunner:
         response = await context._workbench_client.duplicate_conversation(
             new_conversation=NewConversation(
                 title=title,
+                metadata={"parent_conversation_id": context.id},
             )
         )
 

--- a/libraries/python/assistant-extensions/assistant_extensions/workflows/runners/_user_proxy.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/workflows/runners/_user_proxy.py
@@ -8,6 +8,7 @@ from semantic_workbench_api_model.workbench_model import (
     ConversationMessage,
     MessageSender,
     MessageType,
+    NewConversation,
     NewConversationMessage,
     UpdateParticipant,
 )
@@ -101,7 +102,7 @@ class UserProxyRunner:
             )
 
             # duplicate the current conversation and get the context
-            workflow_context = await self.duplicate_conversation(context)
+            workflow_context = await self.duplicate_conversation(context, workflow_definition)
 
             # set the current workflow id
             workflow_state = WorkflowState(
@@ -156,19 +157,38 @@ class UserProxyRunner:
                     continue
                 await self._on_assistant_message(context, workflow_state, message)
 
-    async def duplicate_conversation(self, context: ConversationContext) -> ConversationContext:
+    async def duplicate_conversation(
+        self, context: ConversationContext, workflow_definition: UserProxyWorkflowDefinition
+    ) -> ConversationContext:
         """
         Duplicate the current conversation
         """
 
+        title = f"Workflow: {workflow_definition.name} [{context.title}]"
+
         # duplicate the current conversation
-        response = await context._workbench_client.duplicate_conversation()
+        response = await context._workbench_client.duplicate_conversation(
+            new_conversation=NewConversation(
+                title=title,
+            )
+        )
+
+        conversation_id = response.conversation_ids[0]
 
         # create a new conversation context
         workflow_context = ConversationContext(
-            id=str(response.conversation_ids[0]),
-            title="Workflow",
+            id=str(conversation_id),
+            title=title,
             assistant=context.assistant,
+        )
+
+        # send link to chat for the new conversation
+        await context.send_messages(
+            NewConversationMessage(
+                content=f"New conversation: {title}",
+                message_type=MessageType.command_response,
+                metadata={"attribution": "workflows:user_proxy", "href": f"/{conversation_id}"},
+            )
         )
 
         # return the new conversation context
@@ -187,7 +207,7 @@ class UserProxyRunner:
         await workflow_state.context.send_messages(
             NewConversationMessage(
                 sender=workflow_state.send_as,
-                content=user_message,
+                content=user_message.message,
                 message_type=MessageType.chat,
                 metadata={"attribution": "user"},
             )
@@ -199,7 +219,7 @@ class UserProxyRunner:
         # )
         await context.update_participant_me(
             UpdateParticipant(
-                status=f"Workflow {workflow_state.definition.name}: Step {workflow_state.current_step}, awaiting assistant response..."
+                status=f"Workflow {workflow_state.definition.name} [Step {workflow_state.current_step} - {user_message.status_label}]: awaiting assistant response..."
             )
         )
 
@@ -258,7 +278,7 @@ class UserProxyRunner:
             NewConversationMessage(
                 content=assistant_response.content,
                 message_type=MessageType.chat,
-                metadata={"attribution": "system"},
+                metadata={"attribution": "workflows:user_proxy"},
             )
         )
 

--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_service_client.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_service_client.py
@@ -117,9 +117,14 @@ class ConversationAPIClient:
                 return
             http_response.raise_for_status()
 
-    async def duplicate_conversation(self) -> workbench_model.ConversationImportResult:
+    async def duplicate_conversation(
+        self, new_conversation: workbench_model.NewConversation
+    ) -> workbench_model.ConversationImportResult:
         async with self._client as client:
-            http_response = await client.post(f"/conversations/duplicate?id={self._conversation_id}")
+            http_response = await client.post(
+                f"/conversations/{self._conversation_id}",
+                json=new_conversation.model_dump(exclude_defaults=True, exclude_unset=True, mode="json"),
+            )
             http_response.raise_for_status()
             return workbench_model.ConversationImportResult.model_validate(http_response.json())
 

--- a/workbench-app/docs/MESSAGE_METADATA.md
+++ b/workbench-app/docs/MESSAGE_METADATA.md
@@ -6,6 +6,8 @@ The app has built-in support for a few metadata child properties, which can be u
 
 -   `attribution`: A string that will be displayed after the sender of the message. The intent is to allow the sender to indicate the source of the message, possibly coming from an internal part of its system.
 
+-   `href`: If provided, the app will display the message as a hyperlink. The value of this property will be used as the URL of the hyperlink and use the React Router navigation system to navigate to the URL when the user clicks on the message. Will be ignored for messages of type `chat`.
+
 -   `debug`: A dictionary that can contain additional information that can be used for debugging purposes. If included, it will cause the app to display a button that will allow the user to see the contents of the dictionary in a popup for further inspection.
 
 -   `footer_items`: A list of strings that will be displayed in the footer of the message. The intent is to allow the sender to include additional information that is not part of the message body, but is still relevant to the message.

--- a/workbench-app/src/components/Conversations/InteractMessage.tsx
+++ b/workbench-app/src/components/Conversations/InteractMessage.tsx
@@ -30,6 +30,7 @@ import {
     TextBulletListSquareSparkleRegular,
 } from '@fluentui/react-icons';
 import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useConversationUtility } from '../../libs/useConversationUtility';
 import { useParticipantUtility } from '../../libs/useParticipantUtility';
 import { Utility } from '../../libs/Utility';
@@ -157,6 +158,7 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
     const { getAvatarData } = useParticipantUtility();
     const [createConversationMessage] = useCreateConversationMessageMutation();
     const { isMessageVisibleRef, isMessageVisible, isUnread } = useConversationUtility();
+    const navigate = useNavigate();
     const [skipDebugLoad, setSkipDebugLoad] = React.useState(true);
     const {
         data: debugData,
@@ -261,6 +263,7 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
     );
 
     const getRenderedMessage = React.useCallback(() => {
+        let allowLink = true;
         let renderedContent: JSX.Element;
         if (message.messageType === 'notice') {
             renderedContent = (
@@ -299,9 +302,15 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
                 </div>
             );
         } else if (isUser) {
+            allowLink = false;
             renderedContent = <UserMessage>{content}</UserMessage>;
         } else {
+            allowLink = false;
             renderedContent = <CopilotMessage>{content}</CopilotMessage>;
+        }
+
+        if (message.metadata?.href && allowLink) {
+            renderedContent = <Link to={message.metadata?.href}>{renderedContent}</Link>;
         }
 
         const attachmentList =

--- a/workbench-app/src/components/Conversations/InteractMessage.tsx
+++ b/workbench-app/src/components/Conversations/InteractMessage.tsx
@@ -30,7 +30,7 @@ import {
     TextBulletListSquareSparkleRegular,
 } from '@fluentui/react-icons';
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useConversationUtility } from '../../libs/useConversationUtility';
 import { useParticipantUtility } from '../../libs/useParticipantUtility';
 import { Utility } from '../../libs/Utility';
@@ -158,7 +158,6 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
     const { getAvatarData } = useParticipantUtility();
     const [createConversationMessage] = useCreateConversationMessageMutation();
     const { isMessageVisibleRef, isMessageVisible, isUnread } = useConversationUtility();
-    const navigate = useNavigate();
     const [skipDebugLoad, setSkipDebugLoad] = React.useState(true);
     const {
         data: debugData,

--- a/workbench-app/src/components/Conversations/MyConversations.tsx
+++ b/workbench-app/src/components/Conversations/MyConversations.tsx
@@ -63,7 +63,7 @@ export const MyConversations: React.FC<MyConversationsProps> = (props) => {
                                 <ConversationDuplicate conversationId={conversation.id} iconOnly />
                                 <ConversationShare conversation={conversation} iconOnly />
                                 <ConversationRemove
-                                    conversation={conversation}
+                                    conversations={conversation}
                                     participantId={participantId}
                                     iconOnly
                                 />

--- a/workbench-app/src/components/FrontDoor/Controls/ConversationList.tsx
+++ b/workbench-app/src/components/FrontDoor/Controls/ConversationList.tsx
@@ -182,7 +182,7 @@ export const ConversationList: React.FC<ConversationListProps> = (props) => {
                 )}
                 {removeConversation && localUserId && (
                     <ConversationRemoveDialog
-                        conversationId={removeConversation.id}
+                        conversations={removeConversation}
                         participantId={localUserId}
                         onRemove={() => {
                             if (activeConversationId === removeConversation.id) {

--- a/workbench-app/src/components/FrontDoor/Controls/ConversationList.tsx
+++ b/workbench-app/src/components/FrontDoor/Controls/ConversationList.tsx
@@ -30,7 +30,13 @@ const useClasses = makeStyles({
     },
 });
 
-export const ConversationList: React.FC = () => {
+interface ConversationListProps {
+    parentConversationId?: string;
+    hideChildConversations?: boolean;
+}
+
+export const ConversationList: React.FC<ConversationListProps> = (props) => {
+    const { parentConversationId, hideChildConversations } = props;
     const classes = useClasses();
     const environment = useEnvironment();
     const activeConversationId = useAppSelector((state) => state.app.activeConversationId);
@@ -43,6 +49,7 @@ export const ConversationList: React.FC = () => {
         isUninitialized: conversationsUninitialized,
         refetch: refetchConversations,
     } = useGetConversationsQuery();
+    const [filteredConversations, setFilteredConversations] = React.useState<Conversation[]>();
     const [displayedConversations, setDisplayedConversations] = React.useState<Conversation[]>([]);
 
     const [renameConversation, setRenameConversation] = React.useState<Conversation>();
@@ -88,6 +95,30 @@ export const ConversationList: React.FC = () => {
             workbenchUserEvents.removeEventListener('participant.updated', conversationHandler);
         };
     }, [conversationsLoading, conversationsUninitialized, environment.url, refetchConversations]);
+
+    React.useEffect(() => {
+        if (conversationsLoading) {
+            return;
+        }
+
+        setFilteredConversations(
+            conversations?.filter((conversation) => {
+                if (parentConversationId) {
+                    if (hideChildConversations) {
+                        return (
+                            conversation.metadata?.['parent_conversation_id'] === undefined ||
+                            conversation.metadata?.['parent_conversation_id'] !== parentConversationId
+                        );
+                    }
+                    return conversation.metadata?.['parent_conversation_id'] === parentConversationId;
+                }
+                if (hideChildConversations) {
+                    return conversation.metadata?.['parent_conversation_id'] === undefined;
+                }
+                return true;
+            }),
+        );
+    }, [conversations, conversationsLoading, hideChildConversations, parentConversationId]);
 
     const handleUpdateSelectedForActions = React.useCallback((conversationId: string, selected: boolean) => {
         if (selected) {
@@ -185,12 +216,12 @@ export const ConversationList: React.FC = () => {
         <>
             {actionHelpers}
             <ConversationListOptions
-                conversations={conversations}
+                conversations={filteredConversations}
                 selectedForActions={selectedForActions}
                 onSelectedForActionsChanged={setSelectedForActions}
                 onDisplayedConversationsChanged={setDisplayedConversations}
             />
-            {!conversations || conversations.length === 0 ? (
+            {!filteredConversations || filteredConversations.length === 0 ? (
                 <div className={classes.content}>
                     <Text weight="semibold">No conversations found</Text>
                 </div>
@@ -221,5 +252,3 @@ export const ConversationList: React.FC = () => {
         </>
     );
 };
-
-export const MemoizedConversationList = React.memo(ConversationList);

--- a/workbench-app/src/components/FrontDoor/GlobalContent.tsx
+++ b/workbench-app/src/components/FrontDoor/GlobalContent.tsx
@@ -2,7 +2,7 @@
 
 import { makeStyles, shorthands, tokens } from '@fluentui/react-components';
 import React from 'react';
-import { MemoizedConversationList } from './Controls/ConversationList';
+import { ConversationList } from './Controls/ConversationList';
 
 const useClasses = makeStyles({
     root: {
@@ -34,15 +34,15 @@ export const GlobalContent: React.FC<GlobalContentProps> = (props) => {
     const { headerBefore, headerAfter } = props;
     const classes = useClasses();
 
+    const conversationList = React.useMemo(() => <ConversationList hideChildConversations />, []);
+
     return (
         <div className={classes.root}>
             <div className={classes.header}>
                 {headerBefore}
                 {headerAfter}
             </div>
-            <div className={classes.content}>
-                <MemoizedConversationList />
-            </div>
+            <div className={classes.content}>{conversationList}</div>
         </div>
     );
 };

--- a/workbench-app/src/libs/useHistoryUtility.ts
+++ b/workbench-app/src/libs/useHistoryUtility.ts
@@ -121,8 +121,7 @@ export const useHistoryUtility = (conversationId: string) => {
             // add the new participant to the cached participants
             dispatch(
                 updateGetConversationParticipantsQueryData(conversationId, {
-                    participant,
-                    participants: conversationParticipants,
+                    participants: [...(conversationParticipants ?? []), participant],
                 }),
             ),
         [dispatch, conversationId, conversationParticipants],
@@ -134,8 +133,9 @@ export const useHistoryUtility = (conversationId: string) => {
             // update the participant in the cached participants
             dispatch(
                 updateGetConversationParticipantsQueryData(conversationId, {
-                    participant,
-                    participants: conversationParticipants,
+                    participants: (conversationParticipants ?? []).map((existingParticipant) =>
+                        existingParticipant.id === participant.id ? participant : existingParticipant,
+                    ),
                 }),
             ),
         [dispatch, conversationId, conversationParticipants],

--- a/workbench-service/semantic_workbench_service/controller/assistant.py
+++ b/workbench-service/semantic_workbench_service/controller/assistant.py
@@ -31,6 +31,7 @@ from semantic_workbench_api_model.workbench_model import (
     ConversationEventType,
     ConversationImportResult,
     NewAssistant,
+    NewConversation,
     UpdateAssistant,
 )
 from sqlalchemy.orm import joinedload
@@ -829,32 +830,14 @@ class AssistantController:
             conversation_ids=list(import_result.conversation_id_old_to_new.values()),
         )
 
-    # async def duplicate_conversation(
-    #     self,
-    #     user_principal: auth.UserPrincipal,
-    #     conversation_id: uuid.UUID,
-    # ) -> ConversationImportResult:
-    #     # export the conversation
-    #     export_result = await self.export_conversations(
-    #         user_principal=user_principal, conversation_ids={conversation_id}
-    #     )
-
-    #     # import the conversation
-    #     with open(export_result.file_path, "rb") as import_file:
-    #         import_result = await self.import_conversations(from_export=import_file, user_principal=user_principal)
-
-    #     # cleanup
-    #     export_result.cleanup()
-
-    #     return import_result
-
+    # TODO: decide if we should move this to the conversation controller?
+    #   it's a bit of a mix between the two and reaches into the assistant controller
+    #   to access storage and assistant data, so it's not a clean fit in either
+    #   also, we should consider DRYing up the import/export code with this
     async def duplicate_conversation(
-        self,
-        principal: auth.ActorPrincipal,
-        conversation_id: uuid.UUID,
+        self, principal: auth.ActorPrincipal, conversation_id: uuid.UUID, new_conversation: NewConversation
     ) -> ConversationImportResult:
         async with self._get_session() as session:
-            # Ensure the user has access to the conversation
             # Ensure the actor has access to the conversation
             original_conversation = await self._ensure_conversation_access(
                 session=session,
@@ -864,16 +847,24 @@ class AssistantController:
             if original_conversation is None:
                 raise exceptions.NotFoundError()
 
+            title = new_conversation.title or f"{original_conversation.title} (Copy)"
+
+            meta_data = {
+                **original_conversation.meta_data,
+                **new_conversation.metadata,
+                "parent_conversation_id": str(original_conversation.conversation_id),
+            }
+
             # Create a new conversation with the same properties
-            new_conversation = db.Conversation(
+            conversation = db.Conversation(
                 owner_id=original_conversation.owner_id,
-                title=f"{original_conversation.title} (Copy)",
-                meta_data=original_conversation.meta_data.copy(),
+                title=title,
+                meta_data=meta_data,
                 imported_from_conversation_id=original_conversation.conversation_id,
                 # Use the current datetime for the new conversation
                 created_datetime=datetime.datetime.now(datetime.UTC),
             )
-            session.add(new_conversation)
+            session.add(conversation)
             await session.flush()  # To generate new_conversation.conversation_id
 
             # Copy messages from the original conversation
@@ -886,7 +877,7 @@ class AssistantController:
                 new_message = db.ConversationMessage(
                     # Do not set 'sequence'; let the database assign it
                     message_id=uuid.uuid4(),  # Generate a new unique message ID
-                    conversation_id=new_conversation.conversation_id,
+                    conversation_id=conversation.conversation_id,
                     created_datetime=message.created_datetime,
                     sender_participant_id=message.sender_participant_id,
                     sender_participant_role=message.sender_participant_role,
@@ -902,7 +893,7 @@ class AssistantController:
             original_files_path = self._file_storage.path_for(
                 namespace=str(original_conversation.conversation_id), filename=""
             )
-            new_files_path = self._file_storage.path_for(namespace=str(new_conversation.conversation_id), filename="")
+            new_files_path = self._file_storage.path_for(namespace=str(conversation.conversation_id), filename="")
             if original_files_path.exists():
                 await asyncio.to_thread(shutil.copytree, original_files_path, new_files_path)
 
@@ -918,7 +909,7 @@ class AssistantController:
             ).all()
             for participant in assistant_participants:
                 new_participant = db.AssistantParticipant(
-                    conversation_id=new_conversation.conversation_id,
+                    conversation_id=conversation.conversation_id,
                     assistant_id=participant.assistant_id,
                     name=participant.name,
                     image=participant.image,
@@ -938,7 +929,7 @@ class AssistantController:
             )
             for participant in user_participants:
                 new_user_participant = db.UserParticipant(
-                    conversation_id=new_conversation.conversation_id,
+                    conversation_id=conversation.conversation_id,
                     user_id=participant.user_id,
                     name=participant.name,
                     image=participant.image,
@@ -974,20 +965,20 @@ class AssistantController:
 
                     # **Connect the assistant to the new conversation with the exported data**
                     await self.connect_assistant_to_conversation(
-                        conversation=new_conversation,
+                        conversation=conversation,
                         assistant=assistant,
                         from_export=from_export,
                     )
                 except AssistantError as e:
                     logger.error(
-                        f"Error connecting assistant {assistant_id} to new conversation {new_conversation.conversation_id}: {e}",
+                        f"Error connecting assistant {assistant_id} to new conversation {conversation.conversation_id}: {e}",
                         exc_info=True,
                     )
                     # Optionally handle the error (e.g., remove assistant from the conversation)
 
             return ConversationImportResult(
                 assistant_ids=list(assistant_ids),
-                conversation_ids=[new_conversation.conversation_id],
+                conversation_ids=[conversation.conversation_id],
             )
 
     async def _ensure_conversation_access(

--- a/workbench-service/semantic_workbench_service/controller/assistant.py
+++ b/workbench-service/semantic_workbench_service/controller/assistant.py
@@ -852,7 +852,7 @@ class AssistantController:
             meta_data = {
                 **original_conversation.meta_data,
                 **new_conversation.metadata,
-                "parent_conversation_id": str(original_conversation.conversation_id),
+                "original_conversation_id": str(original_conversation.conversation_id),
             }
 
             # Create a new conversation with the same properties

--- a/workbench-service/semantic_workbench_service/service.py
+++ b/workbench-service/semantic_workbench_service/service.py
@@ -504,13 +504,6 @@ def init(
             user_principal=user_principal, from_export=from_export.file
         )
 
-    @app.post("/conversations/duplicate")
-    async def duplicate_conversation(
-        principal: auth.DependsActorPrincipal,
-        conversation_id: uuid.UUID = Query(alias="id"),
-    ) -> ConversationImportResult:
-        return await assistant_controller.duplicate_conversation(principal=principal, conversation_id=conversation_id)
-
     @app.get("/assistants/{assistant_id}/config")
     async def get_assistant_config(
         user_principal: auth.DependsUserPrincipal,
@@ -759,6 +752,16 @@ def init(
         return await conversation_controller.create_conversation(
             user_principal=user_principal,
             new_conversation=new_conversation,
+        )
+
+    @app.post("/conversations/{conversation_id}")
+    async def duplicate_conversation(
+        conversation_id: uuid.UUID,
+        principal: auth.DependsActorPrincipal,
+        new_conversation: NewConversation,
+    ) -> ConversationImportResult:
+        return await assistant_controller.duplicate_conversation(
+            principal=principal, conversation_id=conversation_id, new_conversation=new_conversation
         )
 
     @app.get("/conversations")


### PR DESCRIPTION
Reduces noise from workflow conversations:
* Adds parent_conversation_id as metadata on duplicated conversations
* Updates ConversationList to take optional:
    * parentConversationId: only show children of this conversation
    * hideChildConversations: hide children of the current level of conversations
* Global conversation list is set to hide child conversations
* Adds notice at start of workflow that includes new href metadata for link to workflow conversation
* Updates rendering of InteractMessage to use React Router links to wrap non-chat message content if href metadata is provided
* Updates UX docs regarding message metadata handling

Updates ConversationListOptions to allow bulk removal of conversations

Fixes status messages for workflow steps

Updates workflows config for user proxy workflow definitions:
* Steps now include a label for use in status messages
* User message input now uses multiline text field

Changed conversation_duplicate endpoint:
* post -> /conversations/{conversation_id}
* takes title for new conversation and optional metadata to merge w/ existing conversation metadata and add original_conversation_id

Removes commented out code for alt approach to conversation_duplicate via export/import
