### PR TITLE
Adds `make type-check`

### DIFF
--- a/.github/workflows/assistants-explorer-assistant.yml
+++ b/.github/workflows/assistants-explorer-assistant.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
       - name: test
         run: |
           make test

--- a/.github/workflows/assistants-explorer-assistant.yml
+++ b/.github/workflows/assistants-explorer-assistant.yml
@@ -24,8 +24,21 @@ defaults:
     working-directory: assistants/explorer-assistant
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: test
+        run: |
+          make test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/assistants-guided-conversation-assistant.yml
+++ b/.github/workflows/assistants-guided-conversation-assistant.yml
@@ -24,8 +24,21 @@ defaults:
     working-directory: assistants/guided-conversation-assistant
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: test
+        run: |
+          make test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/assistants-guided-conversation-assistant.yml
+++ b/.github/workflows/assistants-guided-conversation-assistant.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
       - name: test
         run: |
           make test

--- a/.github/workflows/assistants-prospector-assistant.yml
+++ b/.github/workflows/assistants-prospector-assistant.yml
@@ -24,8 +24,21 @@ defaults:
     working-directory: assistants/prospector-assistant
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: test
+        run: |
+          make test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/assistants-prospector-assistant.yml
+++ b/.github/workflows/assistants-prospector-assistant.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
       - name: test
         run: |
           make test

--- a/.github/workflows/assistants-skill-assistant.yml
+++ b/.github/workflows/assistants-skill-assistant.yml
@@ -24,8 +24,21 @@ defaults:
     working-directory: assistants/skill-assistant
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: test
+        run: |
+          make test
+
   build:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/assistants-skill-assistant.yml
+++ b/.github/workflows/assistants-skill-assistant.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
 
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
       - name: test
         run: |
           make test

--- a/.github/workflows/workbench-service.yml
+++ b/.github/workflows/workbench-service.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: pytest
-        run: uv run pytest --dbtype=${{ matrix.dbtype }}
+      - name: test
+        run: make test PYTEST_ARGS="--dbtype=${{ matrix.dbtype }}"
 
   build:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,7 @@
   ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/workbench-service/.venv",
   "python.languageServer": "Pylance",
   "python.testing.pytestEnabled": true,

--- a/assistants/explorer-assistant/.vscode/settings.json
+++ b/assistants/explorer-assistant/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/assistants/explorer-assistant/assistant/config.py
+++ b/assistants/explorer-assistant/assistant/config.py
@@ -151,7 +151,7 @@ class AssistantConfigModel(BaseModel):
         " code snippets, and other types of content. If you wrap your response in triple backticks, you can specify the"
         " language for syntax highlighting. For example, ```python print('Hello, World!')``` will produce a code"
         " snippet in Python. Mermaid markdown is supported if you wrap the content in triple backticks and specify"
-        " 'mermaid' as the language. For example, ```mermaid graph TD; A-->B;``` will render a flowchart for the"
+        ' \'mermaid\' as the language. For example, ```mermaid graph TD; A["A"]-->B["B"];``` will render a flowchart for the'
         " user.ABC markdown is supported if you wrap the content in triple backticks and specify 'abc' as the"
         " language.For example, ```abc C4 G4 A4 F4 E4 G4``` will render a music score and an inline player with a link"
         " to download the midi file."

--- a/assistants/explorer-assistant/pyproject.toml
+++ b/assistants/explorer-assistant/pyproject.toml
@@ -30,3 +30,8 @@ assistant-extensions = { path = "../../libraries/python/assistant-extensions", e
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/assistants/explorer-assistant/uv.lock
+++ b/assistants/explorer-assistant/uv.lock
@@ -144,6 +144,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -178,6 +179,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
 ]
@@ -398,6 +400,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "context"
 version = "0.1.0"
@@ -411,6 +416,7 @@ requires-dist = [{ name = "events", editable = "../../libraries/python/events" }
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -502,6 +508,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "explorer-assistant"
 version = "0.1.0"
@@ -516,6 +525,11 @@ dependencies = [
     { name = "openai-client" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "assistant-extensions", extras = ["attachments"], editable = "../../libraries/python/assistant-extensions" },
@@ -526,6 +540,9 @@ requires-dist = [
     { name = "openai", specifier = ">=1.3.9" },
     { name = "openai-client", editable = "../../libraries/python/openai-client" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -990,6 +1007,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1038,7 +1064,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1321,6 +1350,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1545,6 +1587,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1575,6 +1620,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/assistants/guided-conversation-assistant/.vscode/settings.json
+++ b/assistants/guided-conversation-assistant/.vscode/settings.json
@@ -28,7 +28,7 @@
   ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/assistants/guided-conversation-assistant/pyproject.toml
+++ b/assistants/guided-conversation-assistant/pyproject.toml
@@ -33,5 +33,10 @@ openai-client = { path = "../../libraries/python/openai-client", editable = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]
+
 [tool.pyright]
 exclude = ["venv", ".venv"]

--- a/assistants/guided-conversation-assistant/uv.lock
+++ b/assistants/guided-conversation-assistant/uv.lock
@@ -141,6 +141,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "content-safety", editable = "../../libraries/python/content-safety" },
@@ -156,6 +161,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "attrs"
@@ -367,6 +375,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "cryptography"
 version = "43.0.1"
@@ -474,6 +485,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "fastapi"
 version = "0.115.0"
@@ -565,6 +579,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "semantic-kernel", specifier = ">=1.11.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "h11"
@@ -1007,6 +1024,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1101,7 +1127,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "openapi-core"
@@ -1464,6 +1493,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1806,6 +1848,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1836,6 +1881,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/assistants/prospector-assistant/.vscode/settings.json
+++ b/assistants/prospector-assistant/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/assistants/prospector-assistant/assistant/agents/document/config.py
+++ b/assistants/prospector-assistant/assistant/agents/document/config.py
@@ -63,6 +63,35 @@ def create_pydantic_model_from_json_schema(schema: Dict[str, Any], model_name="D
 #
 
 
+class ResourceConstraintConfigModel(ResourceConstraint):
+    mode: Annotated[
+        ResourceConstraintMode,
+        Field(
+            title="Resource Mode",
+            description=(
+                'If "exact", the agents will try to pace the conversation to use exactly the resource quantity. If'
+                ' "maximum", the agents will try to pace the conversation to use at most the resource quantity.'
+            ),
+        ),
+    ] = config_defaults.resource_constraint.mode
+
+    unit: Annotated[
+        ResourceConstraintUnit,
+        Field(
+            title="Resource Unit",
+            description="The unit for the resource constraint.",
+        ),
+    ] = config_defaults.resource_constraint.unit
+
+    quantity: Annotated[
+        float,
+        Field(
+            title="Resource Quantity",
+            description="The quantity for the resource constraint. If <=0, the resource constraint is disabled.",
+        ),
+    ] = config_defaults.resource_constraint.quantity
+
+
 class GuidedConversationConfigModel(BaseModel):
     enabled: Annotated[
         bool,
@@ -103,41 +132,13 @@ class GuidedConversationConfigModel(BaseModel):
         UISchema(widget="textarea", placeholder="[optional]"),
     ] = config_defaults.context.strip()
 
-    class ResourceConstraint(ResourceConstraint):
-        mode: Annotated[
-            ResourceConstraintMode,
-            Field(
-                title="Resource Mode",
-                description=(
-                    'If "exact", the agents will try to pace the conversation to use exactly the resource quantity. If'
-                    ' "maximum", the agents will try to pace the conversation to use at most the resource quantity.'
-                ),
-            ),
-        ] = config_defaults.resource_constraint.mode
-
-        unit: Annotated[
-            ResourceConstraintUnit,
-            Field(
-                title="Resource Unit",
-                description="The unit for the resource constraint.",
-            ),
-        ] = config_defaults.resource_constraint.unit
-
-        quantity: Annotated[
-            float,
-            Field(
-                title="Resource Quantity",
-                description="The quantity for the resource constraint. If <=0, the resource constraint is disabled.",
-            ),
-        ] = config_defaults.resource_constraint.quantity
-
     resource_constraint: Annotated[
-        ResourceConstraint,
+        ResourceConstraintConfigModel,
         Field(
             title="Resource Constraint",
         ),
         UISchema(schema={"quantity": {"ui:widget": "updown"}}),
-    ] = ResourceConstraint()
+    ] = ResourceConstraintConfigModel()
 
     def get_artifact_model(self) -> Type[BaseModel]:
         schema = json.loads(self.artifact)

--- a/assistants/prospector-assistant/assistant/agents/document/gc_attachment_check_config.py
+++ b/assistants/prospector-assistant/assistant/agents/document/gc_attachment_check_config.py
@@ -7,7 +7,7 @@ from semantic_workbench_assistant.config import UISchema
 
 from ... import helpers
 from . import config_defaults as config_defaults
-from .config import GuidedConversationConfigModel
+from .config import GuidedConversationConfigModel, ResourceConstraintConfigModel
 
 if TYPE_CHECKING:
     pass
@@ -150,41 +150,17 @@ class GCAttachmentCheckConfigModel(GuidedConversationConfigModel):
         UISchema(widget="textarea", placeholder="[optional]"),
     ] = context.strip()
 
-    class ResourceConstraint(ResourceConstraint):
-        mode: Annotated[
-            ResourceConstraintMode,
-            Field(
-                title="Resource Mode",
-                description=(
-                    'If "exact", the agents will try to pace the conversation to use exactly the resource quantity. If'
-                    ' "maximum", the agents will try to pace the conversation to use at most the resource quantity.'
-                ),
-            ),
-        ] = resource_constraint.mode
-
-        unit: Annotated[
-            ResourceConstraintUnit,
-            Field(
-                title="Resource Unit",
-                description="The unit for the resource constraint.",
-            ),
-        ] = resource_constraint.unit
-
-        quantity: Annotated[
-            float,
-            Field(
-                title="Resource Quantity",
-                description="The quantity for the resource constraint. If <=0, the resource constraint is disabled.",
-            ),
-        ] = resource_constraint.quantity
-
     resource_constraint: Annotated[
-        ResourceConstraint,
+        ResourceConstraintConfigModel,
         Field(
             title="Resource Constraint",
         ),
         UISchema(schema={"quantity": {"ui:widget": "updown"}}),
-    ] = ResourceConstraint()
+    ] = ResourceConstraintConfigModel(
+        unit=resource_constraint.unit,
+        quantity=resource_constraint.quantity,
+        mode=resource_constraint.mode,
+    )
 
     def get_artifact_model(self) -> Type[BaseModel]:
         schema = json.loads(self.artifact)

--- a/assistants/prospector-assistant/assistant/agents/document/gc_draft_outline_feedback_config.py
+++ b/assistants/prospector-assistant/assistant/agents/document/gc_draft_outline_feedback_config.py
@@ -7,7 +7,7 @@ from semantic_workbench_assistant.config import UISchema
 
 from ... import helpers
 from . import config_defaults as config_defaults
-from .config import GuidedConversationConfigModel
+from .config import GuidedConversationConfigModel, ResourceConstraintConfigModel
 
 if TYPE_CHECKING:
     pass
@@ -189,41 +189,17 @@ class GCDraftOutlineFeedbackConfigModel(GuidedConversationConfigModel):
         UISchema(widget="textarea", placeholder="[optional]"),
     ] = context.strip()
 
-    class ResourceConstraint(ResourceConstraint):
-        mode: Annotated[
-            ResourceConstraintMode,
-            Field(
-                title="Resource Mode",
-                description=(
-                    'If "exact", the agents will try to pace the conversation to use exactly the resource quantity. If'
-                    ' "maximum", the agents will try to pace the conversation to use at most the resource quantity.'
-                ),
-            ),
-        ] = resource_constraint.mode
-
-        unit: Annotated[
-            ResourceConstraintUnit,
-            Field(
-                title="Resource Unit",
-                description="The unit for the resource constraint.",
-            ),
-        ] = resource_constraint.unit
-
-        quantity: Annotated[
-            float,
-            Field(
-                title="Resource Quantity",
-                description="The quantity for the resource constraint. If <=0, the resource constraint is disabled.",
-            ),
-        ] = resource_constraint.quantity
-
     resource_constraint: Annotated[
-        ResourceConstraint,
+        ResourceConstraintConfigModel,
         Field(
             title="Resource Constraint",
         ),
         UISchema(schema={"quantity": {"ui:widget": "updown"}}),
-    ] = ResourceConstraint()
+    ] = ResourceConstraintConfigModel(
+        unit=resource_constraint.unit,
+        quantity=resource_constraint.quantity,
+        mode=resource_constraint.mode,
+    )
 
     def get_artifact_model(self) -> Type[BaseModel]:
         schema = json.loads(self.artifact)

--- a/assistants/prospector-assistant/assistant/agents/document_agent.py
+++ b/assistants/prospector-assistant/assistant/agents/document_agent.py
@@ -164,6 +164,8 @@ class Mode(BaseModel):
             status = Status.UNDEFINED
             return Step(name=next_step_name, status=status)
 
+        next_step_name = StepName.UNDEFINED
+        status = Status.UNDEFINED
         for index, step in enumerate(steps[:-1]):
             current_step_name = step.get("step_name")
             if isinstance(current_step_name, StepName):
@@ -179,8 +181,6 @@ class Mode(BaseModel):
                         break
             else:
                 logger.error("step_name is not StepName instance")
-                next_step_name = StepName.UNDEFINED
-                status = Status.UNDEFINED
                 break
 
         return Step(name=next_step_name, status=status)
@@ -853,6 +853,8 @@ class DocumentAgent:
         else:
             logger.error("artifact_dict unavailable.")
 
+        conversation_status = Status.UNDEFINED
+        next_step_name = None
         # run guided conversation step
         try:
             if message is None:
@@ -911,6 +913,7 @@ class DocumentAgent:
 
         # get conversation related info -- for now, if no message, assuming no prior conversation
         conversation = None
+        participants_list = None
         if message is not None:
             conversation = await context.get_messages(before=message.id)
             if message.message_type == MessageType.chat:
@@ -931,7 +934,7 @@ class DocumentAgent:
         # create chat completion messages
         chat_completion_messages: list[ChatCompletionMessageParam] = []
         chat_completion_messages.append(_draft_outline_main_system_message())
-        if conversation is not None:
+        if conversation is not None and participants_list is not None:
             chat_completion_messages.append(
                 _chat_history_system_message(conversation.messages, participants_list.participants)
             )
@@ -1005,6 +1008,7 @@ class DocumentAgent:
         # This step info approach is not cool. Rewriting code. Need to refactor.
         step_name = self._state.mode.get_step().get_name()
         step_list = self._state.mode.get_step_order()
+        step_run_count = None
         for step in step_list:
             list_step_name = step.get("step_name")
             if isinstance(list_step_name, StepName):
@@ -1054,6 +1058,8 @@ class DocumentAgent:
         else:
             logger.error("artifact_dict unavailable.")
 
+        conversation_status = Status.UNDEFINED
+        next_step_name = None
         # run guided conversation step
         try:
             if message is None:
@@ -1112,6 +1118,7 @@ class DocumentAgent:
 
         # get conversation related info -- for now, if no message, assuming no prior conversation
         conversation = None
+        participants_list = None
         if message is not None:
             conversation = await context.get_messages(before=message.id)
             if message.message_type == MessageType.chat:
@@ -1126,7 +1133,7 @@ class DocumentAgent:
         # create chat completion messages
         chat_completion_messages: list[ChatCompletionMessageParam] = []
         chat_completion_messages.append(_draft_content_main_system_message())
-        if conversation is not None:
+        if conversation is not None and participants_list is not None:
             chat_completion_messages.append(
                 _chat_history_system_message(conversation.messages, participants_list.participants)
             )

--- a/assistants/prospector-assistant/assistant/chat.py
+++ b/assistants/prospector-assistant/assistant/chat.py
@@ -176,6 +176,7 @@ async def on_conversation_created(context: ConversationContext) -> None:
             )
         case _:
             logger.error("Guided workflow unknown or not supported.")
+            return
 
     background_tasks.add(task)
     task.add_done_callback(background_tasks.remove)

--- a/assistants/prospector-assistant/pyproject.toml
+++ b/assistants/prospector-assistant/pyproject.toml
@@ -37,3 +37,8 @@ skill-library = { path = "../../libraries/python/skills/skill-library", editable
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/assistants/prospector-assistant/uv.lock
+++ b/assistants/prospector-assistant/uv.lock
@@ -142,6 +142,11 @@ dependencies = [
     { name = "skill-library" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "assistant-extensions", extras = ["attachments"], editable = "../../libraries/python/assistant-extensions" },
@@ -157,6 +162,9 @@ requires-dist = [
     { name = "prospector-skill", editable = "../../libraries/python/skills/skills/prospector-skill" },
     { name = "skill-library", editable = "../../libraries/python/skills/skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "assistant-drive"
@@ -178,6 +186,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -212,6 +221,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
 ]
@@ -426,6 +436,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "context"
 version = "0.1.0"
@@ -439,6 +452,7 @@ requires-dist = [{ name = "events", editable = "../../libraries/python/events" }
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -540,6 +554,9 @@ requires-dist = [
     { name = "skill-library", editable = "../../libraries/python/skills/skill-library" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "docx2txt"
 version = "0.8"
@@ -569,6 +586,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -661,6 +681,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "semantic-kernel", specifier = ">=1.11.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "h11"
@@ -1103,6 +1126,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "numpy"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1197,7 +1229,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "openapi-core"
@@ -1421,6 +1456,9 @@ requires-dist = [
     { name = "skill-library", editable = "../../libraries/python/skills/skill-library" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "prance"
 version = "23.6.21.0"
@@ -1512,6 +1550,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../libraries/python/openai-client" },
     { name = "skill-library", editable = "../../libraries/python/skills/skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "pybars4"
@@ -1652,6 +1693,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/47/eda4904f715fb98561e34012826e883816945934a851745570521ec89520/pypdfium2-4.30.0-py3-none-win32.whl", hash = "sha256:ee2410f15d576d976c2ab2558c93d392a25fb9f6635e8dd0a8a3a5241b275e0e", size = 2775951 },
     { url = "https://files.pythonhosted.org/packages/25/bd/56d9ec6b9f0fc4e0d95288759f3179f0fcd34b1a1526b75673d2f6d5196f/pypdfium2-4.30.0-py3-none-win_amd64.whl", hash = "sha256:90dbb2ac07be53219f56be09961eb95cf2473f834d01a42d901d13ccfad64b4c", size = 2892098 },
     { url = "https://files.pythonhosted.org/packages/be/7a/097801205b991bc3115e8af1edb850d30aeaf0118520b016354cf5ccd3f6/pypdfium2-4.30.0-py3-none-win_arm64.whl", hash = "sha256:119b2969a6d6b1e8d55e99caaf05290294f2d0fe49c12a3f17102d01c441bd29", size = 2752118 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -2009,6 +2063,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -2039,6 +2096,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -2095,6 +2153,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/assistants/skill-assistant/.vscode/settings.json
+++ b/assistants/skill-assistant/.vscode/settings.json
@@ -24,7 +24,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": false,
   "[python]": {

--- a/assistants/skill-assistant/assistant/skill_event_mapper.py
+++ b/assistants/skill-assistant/assistant/skill_event_mapper.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 # TODO: Put this protocol in the skill library.
 class SkillEventMapperProtocol(Protocol):
-    @staticmethod
     async def map(
+        self,
         skill_event: skill_events.EventProtocol,
     ) -> None: ...
 

--- a/assistants/skill-assistant/pyproject.toml
+++ b/assistants/skill-assistant/pyproject.toml
@@ -34,3 +34,8 @@ semantic-workbench-assistant = { path = "../../libraries/python/semantic-workben
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/assistants/skill-assistant/uv.lock
+++ b/assistants/skill-assistant/uv.lock
@@ -150,6 +150,11 @@ dependencies = [
     { name = "semantic-workbench-assistant" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-ai-contentsafety", specifier = ">=1.0.0" },
@@ -163,6 +168,9 @@ requires-dist = [
     { name = "posix-skill", editable = "../../libraries/python/skills/skills/posix-skill" },
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "assistant-drive"
@@ -184,6 +192,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -433,6 +442,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "context"
 version = "0.1.0"
@@ -446,6 +458,7 @@ requires-dist = [{ name = "events", editable = "../../libraries/python/events" }
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -551,6 +564,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "fastapi"
 version = "0.115.4"
@@ -619,6 +635,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.4" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -1015,6 +1032,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.54.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1063,7 +1089,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1171,6 +1200,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../libraries/python/openai-client" },
     { name = "skill-library", editable = "../../libraries/python/skills/skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "propcache"
@@ -1338,6 +1370,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1540,6 +1585,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1570,6 +1618,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1626,6 +1675,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/examples/python/python-01-echo-bot/.vscode/settings.json
+++ b/examples/python/python-01-echo-bot/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/examples/python/python-01-echo-bot/pyproject.toml
+++ b/examples/python/python-01-echo-bot/pyproject.toml
@@ -16,3 +16,8 @@ semantic-workbench-assistant = { path = "../../../libraries/python/semantic-work
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/examples/python/python-01-echo-bot/uv.lock
+++ b/examples/python/python-01-echo-bot/uv.lock
@@ -48,11 +48,19 @@ dependencies = [
     { name = "semantic-workbench-assistant" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "openai", specifier = ">=1.3.9" },
     { name = "semantic-workbench-assistant", editable = "../../../libraries/python/semantic-workbench-assistant" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "backoff"
@@ -338,6 +346,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -440,6 +457,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -529,6 +559,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -559,6 +592,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/examples/python/python-02-simple-chatbot/.vscode/settings.json
+++ b/examples/python/python-02-simple-chatbot/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/examples/python/python-02-simple-chatbot/pyproject.toml
+++ b/examples/python/python-02-simple-chatbot/pyproject.toml
@@ -24,3 +24,8 @@ openai-client = { path = "../../../libraries/python/openai-client", editable = t
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/examples/python/python-02-simple-chatbot/uv.lock
+++ b/examples/python/python-02-simple-chatbot/uv.lock
@@ -133,6 +133,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "content-safety", editable = "../../../libraries/python/content-safety" },
@@ -141,6 +146,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../../libraries/python/semantic-workbench-assistant" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "attrs"
@@ -343,6 +351,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "cryptography"
 version = "43.0.1"
@@ -422,6 +433,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -769,6 +783,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -817,7 +840,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "pillow"
@@ -984,6 +1010,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1183,6 +1222,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1213,6 +1255,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/examples/python/python-03-multimodel-chatbot/.vscode/settings.json
+++ b/examples/python/python-03-multimodel-chatbot/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/examples/python/python-03-multimodel-chatbot/assistant/chat.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/chat.py
@@ -235,7 +235,7 @@ async def respond_to_conversation(
             messages.append(Message(role, content))
 
         # get the model adapter
-        adapter = get_model_adapter(config.service_config.service_type)
+        adapter = get_model_adapter(config.service_config.llm_service_type)
 
         # generate a response from the AI model
         result = await adapter.generate_response(messages, config.request_config, config.service_config)

--- a/examples/python/python-03-multimodel-chatbot/assistant/config.py
+++ b/examples/python/python-03-multimodel-chatbot/assistant/config.py
@@ -1,7 +1,7 @@
 import pathlib
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 import google.generativeai as genai
 import openai
@@ -48,19 +48,12 @@ class ServiceType(StrEnum):
 
 
 class ServiceConfig(ABC, BaseModel):
-    model_config = ConfigDict(
-        title="Service Configuration",
-        json_schema_extra={
-            "required": ["service_type"],
-        },
-    )
-
-    service_type: Annotated[str, UISchema(widget="hidden")] = ""
+    llm_service_type: Annotated[ServiceType, UISchema(widget="hidden")]
 
     @property
     def service_type_display_name(self) -> str:
         # get from the class title
-        return self.model_config.get("title") or self.service_type
+        return self.model_config.get("title") or self.llm_service_type
 
     @abstractmethod
     def new_client(self, **kwargs) -> Any:
@@ -83,7 +76,7 @@ class AzureOpenAIServiceConfig(ServiceConfig, openai_client.AzureOpenAIServiceCo
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.AzureOpenAI], UISchema(widget="hidden")] = ServiceType.AzureOpenAI
+    llm_service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.AzureOpenAI
 
     openai_model: Annotated[
         str,
@@ -110,7 +103,7 @@ class OpenAIServiceConfig(ServiceConfig, openai_client.OpenAIServiceConfig):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.OpenAI], UISchema(widget="hidden")] = ServiceType.OpenAI
+    llm_service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.OpenAI
 
     openai_model: Annotated[
         str,
@@ -136,7 +129,7 @@ class AnthropicServiceConfig(ServiceConfig):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.Anthropic], UISchema(widget="hidden")] = ServiceType.Anthropic
+    service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.Anthropic
 
     anthropic_api_key: Annotated[
         # ConfigSecretStr is a custom type that should be used for any secrets.
@@ -172,7 +165,7 @@ class GeminiServiceConfig(ServiceConfig):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.Gemini], UISchema(widget="hidden")] = ServiceType.Gemini
+    service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.Gemini
 
     gemini_api_key: Annotated[
         # ConfigSecretStr is a custom type that should be used for any secrets.
@@ -209,7 +202,7 @@ class OllamaServiceConfig(ServiceConfig):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.Ollama], UISchema(widget="hidden")] = ServiceType.Ollama
+    service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.Ollama
 
     ollama_endpoint: Annotated[
         str,
@@ -337,7 +330,7 @@ class AssistantConfigModel(BaseModel):
         | OllamaServiceConfig,
         Field(
             title="Service Configuration",
-            discriminator="service_type",
+            discriminator="llm_service_type",
         ),
         UISchema(widget="radio", hide_title=True),
     ] = AzureOpenAIServiceConfig.model_construct()

--- a/examples/python/python-03-multimodel-chatbot/pyproject.toml
+++ b/examples/python/python-03-multimodel-chatbot/pyproject.toml
@@ -26,3 +26,8 @@ openai-client = { path = "../../../libraries/python/openai-client", editable = t
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/examples/python/python-03-multimodel-chatbot/uv.lock
+++ b/examples/python/python-03-multimodel-chatbot/uv.lock
@@ -154,6 +154,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.34.2" },
@@ -164,6 +169,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../../libraries/python/semantic-workbench-assistant" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "attrs"
@@ -375,6 +383,9 @@ requires-dist = [
     { name = "semantic-workbench-assistant", editable = "../../../libraries/python/semantic-workbench-assistant" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "cryptography"
 version = "43.0.1"
@@ -454,6 +465,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -1008,6 +1022,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1056,7 +1079,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1291,6 +1317,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1499,6 +1538,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1529,6 +1571,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/libraries/python/assistant-drive/.vscode/settings.json
+++ b/libraries/python/assistant-drive/.vscode/settings.json
@@ -23,7 +23,7 @@
   ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "python.testing.pytestArgs": ["--color", "yes"],

--- a/libraries/python/assistant-drive/pyproject.toml
+++ b/libraries/python/assistant-drive/pyproject.toml
@@ -20,6 +20,7 @@ dev-dependencies = [
     "pytest-asyncio>=0.23.8",
     "pytest-repeat>=0.9.3",
     "ipykernel>=6.29.5",
+    "pyright>=1.1.389",
 ]
 
 [tool.uv.sources]

--- a/libraries/python/assistant-drive/uv.lock
+++ b/libraries/python/assistant-drive/uv.lock
@@ -36,6 +36,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-repeat" },
@@ -51,6 +52,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -147,6 +149,7 @@ requires-dist = [{ name = "events", editable = "../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -188,6 +191,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "executing"
@@ -316,6 +322,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -381,8 +396,6 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
-    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },
@@ -500,6 +513,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]

--- a/libraries/python/assistant-extensions/.vscode/settings.json
+++ b/libraries/python/assistant-extensions/.vscode/settings.json
@@ -17,7 +17,7 @@
     "source.unusedImports"
   ],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.pytestEnabled": true,
   "[python]": {

--- a/libraries/python/assistant-extensions/pyproject.toml
+++ b/libraries/python/assistant-extensions/pyproject.toml
@@ -20,7 +20,11 @@ attachments = ["docx2txt>=0.8", "pdfplumber>=0.11.2", "assistant-drive>=0.1.0"]
 
 [tool.uv]
 package = true
-dev-dependencies = ["pytest>=8.3.1", "pytest-asyncio>=0.23.8"]
+dev-dependencies = [
+    "pyright>=1.1.389",
+    "pytest>=8.3.1",
+    "pytest-asyncio>=0.23.8",
+]
 
 [tool.uv.sources]
 semantic-workbench-assistant = { path = "../semantic-workbench-assistant", editable = true }

--- a/libraries/python/assistant-extensions/uv.lock
+++ b/libraries/python/assistant-extensions/uv.lock
@@ -59,6 +59,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -83,6 +84,7 @@ attachments = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
@@ -99,6 +101,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
 ]
@@ -254,6 +257,7 @@ requires-dist = [{ name = "events", editable = "../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -344,6 +348,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -591,6 +598,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.2"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +832,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -959,6 +988,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -989,6 +1021,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/libraries/python/content-safety/.vscode/settings.json
+++ b/libraries/python/content-safety/.vscode/settings.json
@@ -23,7 +23,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/libraries/python/content-safety/content_safety/evaluators/azure_content_safety/config.py
+++ b/libraries/python/content-safety/content_safety/evaluators/azure_content_safety/config.py
@@ -142,11 +142,11 @@ class AzureContentSafetyEvaluatorConfig(BaseModel):
     _azure_default_credential: DefaultAzureCredential | None = None
 
     def _get_azure_credentials(self) -> AzureKeyCredential | DefaultAzureCredential:
-        match self.auth_config.auth_method:
-            case AzureAuthConfigType.ServiceKey:
+        match self.auth_config:
+            case AzureServiceKeyAuthConfig():
                 return AzureKeyCredential(self.auth_config.azure_service_api_key)
 
-            case AzureAuthConfigType.Identity:
+            case AzureIdentityAuthConfig():
                 return get_azure_default_credential()
 
 

--- a/libraries/python/content-safety/pyproject.toml
+++ b/libraries/python/content-safety/pyproject.toml
@@ -22,3 +22,8 @@ semantic-workbench-assistant = { path = "../semantic-workbench-assistant", edita
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/content-safety/uv.lock
+++ b/libraries/python/content-safety/uv.lock
@@ -313,6 +313,11 @@ dependencies = [
     { name = "semantic-workbench-assistant" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "azure-ai-contentsafety", specifier = ">=1.0.0" },
@@ -321,6 +326,9 @@ requires-dist = [
     { name = "openai", specifier = ">=1.3.9" },
     { name = "semantic-workbench-assistant", editable = "../semantic-workbench-assistant" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "cryptography"
@@ -728,6 +736,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -865,6 +882,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -982,6 +1012,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1012,6 +1045,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/libraries/python/context/.vscode/settings.json
+++ b/libraries/python/context/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "python.testing.pytestArgs": ["--color", "yes"],

--- a/libraries/python/context/pyproject.toml
+++ b/libraries/python/context/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [tool.uv]
 package = true
 dev-dependencies = [
+    "pyright>=1.1.389",
     "pytest>=8.3.1",
     "pytest-asyncio>=0.23.8",
     "pytest-repeat>=0.9.3",

--- a/libraries/python/context/uv.lock
+++ b/libraries/python/context/uv.lock
@@ -33,6 +33,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-repeat" },
@@ -43,6 +44,7 @@ requires-dist = [{ name = "events", editable = "../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -59,6 +61,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "iniconfig"
 version = "2.0.0"
@@ -66,6 +71,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
 ]
 
 [[package]]
@@ -145,6 +159,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
     { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
     { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]

--- a/libraries/python/events/.vscode/settings.json
+++ b/libraries/python/events/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "search.exclude": {

--- a/libraries/python/events/pyproject.toml
+++ b/libraries/python/events/pyproject.toml
@@ -15,3 +15,8 @@ package = true
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/events/uv.lock
+++ b/libraries/python/events/uv.lock
@@ -22,8 +22,25 @@ dependencies = [
     { name = "pydantic" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
 
 [[package]]
 name = "pydantic"
@@ -84,6 +101,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
     { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
     { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]

--- a/libraries/python/guided-conversation/.vscode/settings.json
+++ b/libraries/python/guided-conversation/.vscode/settings.json
@@ -23,7 +23,7 @@
   ],
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "search.exclude": {

--- a/libraries/python/guided-conversation/pyproject.toml
+++ b/libraries/python/guided-conversation/pyproject.toml
@@ -18,5 +18,10 @@ package = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]
+
 [tool.pyright]
 exclude = [".venv"]

--- a/libraries/python/guided-conversation/uv.lock
+++ b/libraries/python/guided-conversation/uv.lock
@@ -366,8 +366,16 @@ dependencies = [
     { name = "semantic-kernel" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "semantic-kernel", specifier = ">=1.11.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "h11"
@@ -674,6 +682,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
 ]
 
 [[package]]
@@ -995,6 +1012,19 @@ name = "pymeta3"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/af/409edba35fc597f1e386e3860303791ab5a28d6cc9a8aecbc567051b19a9/PyMeta3-0.5.1.tar.gz", hash = "sha256:18bda326d9a9bbf587bfc0ee0bc96864964d78b067288bcf55d4d98681d05bcb", size = 29566 }
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
 
 [[package]]
 name = "python-dotenv"

--- a/libraries/python/openai-client/.vscode/settings.json
+++ b/libraries/python/openai-client/.vscode/settings.json
@@ -17,7 +17,7 @@
     "source.unusedImports"
   ],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.pytestEnabled": true,
   "[python]": {

--- a/libraries/python/openai-client/openai_client/config.py
+++ b/libraries/python/openai-client/openai_client/config.py
@@ -52,7 +52,7 @@ class AzureOpenAIServiceConfig(BaseModel):
         },
     )
 
-    service_type: Annotated[Literal[ServiceType.AzureOpenAI], UISchema(widget="hidden")] = ServiceType.AzureOpenAI
+    service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.AzureOpenAI
 
     auth_config: Annotated[
         AzureOpenAIAzureIdentityAuthConfig | AzureOpenAIApiKeyAuthConfig,
@@ -89,7 +89,7 @@ class AzureOpenAIServiceConfig(BaseModel):
 class OpenAIServiceConfig(BaseModel):
     model_config = ConfigDict(title="OpenAI", json_schema_extra={"required": ["openai_api_key"]})
 
-    service_type: Annotated[Literal[ServiceType.OpenAI], UISchema(widget="hidden")] = ServiceType.OpenAI
+    service_type: Annotated[ServiceType, UISchema(widget="hidden")] = ServiceType.OpenAI
 
     openai_api_key: Annotated[
         # ConfigSecretStr is a custom type that should be used for any secrets.

--- a/libraries/python/openai-client/openai_client/tools.py
+++ b/libraries/python/openai-client/openai_client/tools.py
@@ -389,6 +389,7 @@ class ToolFunctions:
                 "Function call.",
                 extra=add_serializable_data({"name": function.name, "arguments": function.arguments}),
             )
+            value: Any = None
             try:
                 kwargs: dict[str, Any] = json.loads(function.arguments)
                 value = await self.execute_function(function.name, (), kwargs, string_response=True)

--- a/libraries/python/openai-client/pyproject.toml
+++ b/libraries/python/openai-client/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
 
 [tool.uv]
 package = true
-dev-dependencies = ["pytest>=8.3.3"]
+dev-dependencies = [
+    "pyright>=1.1.389",
+    "pytest>=8.3.3",
+]
 
 [tool.uv.sources]
 semantic-workbench-assistant = { path = "../semantic-workbench-assistant", editable = true }

--- a/libraries/python/openai-client/uv.lock
+++ b/libraries/python/openai-client/uv.lock
@@ -381,6 +381,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "fastapi"
 version = "0.115.0"
@@ -736,6 +739,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -772,6 +784,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
 ]
 
@@ -789,7 +802,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -974,6 +990,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1188,6 +1217,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1218,6 +1250,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/libraries/python/semantic-workbench-api-model/.vscode/settings.json
+++ b/libraries/python/semantic-workbench-api-model/.vscode/settings.json
@@ -20,7 +20,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.languageServer": "Pylance",
   "[python]": {

--- a/libraries/python/semantic-workbench-api-model/pyproject.toml
+++ b/libraries/python/semantic-workbench-api-model/pyproject.toml
@@ -16,3 +16,8 @@ package = true
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/semantic-workbench-api-model/uv.lock
+++ b/libraries/python/semantic-workbench-api-model/uv.lock
@@ -264,6 +264,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +340,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -408,11 +430,19 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "asgi-correlation-id", specifier = ">=4.3.1" },
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "shellingham"

--- a/libraries/python/semantic-workbench-assistant/.vscode/settings.json
+++ b/libraries/python/semantic-workbench-assistant/.vscode/settings.json
@@ -32,7 +32,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}",

--- a/libraries/python/semantic-workbench-assistant/pyproject.toml
+++ b/libraries/python/semantic-workbench-assistant/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 package = true
 dev-dependencies = [
     "asgi-lifespan>=2.1.0",
+    "pyright>=1.1.389",
     "pytest>=7.4.3",
     "pytest-asyncio>=0.23.5.post1",
     "pytest-httpx>=0.30.0",

--- a/libraries/python/semantic-workbench-assistant/uv.lock
+++ b/libraries/python/semantic-workbench-assistant/uv.lock
@@ -303,6 +303,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +410,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -533,6 +555,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -551,6 +576,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
@@ -571,6 +597,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },

--- a/libraries/python/skills/notebooks/.vscode/settings.json
+++ b/libraries/python/skills/notebooks/.vscode/settings.json
@@ -17,7 +17,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.cwd": "${workspaceFolder}",
   "python.testing.pytestArgs": ["--color", "yes"],

--- a/libraries/python/skills/notebooks/pyproject.toml
+++ b/libraries/python/skills/notebooks/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 [tool.uv]
 dev-dependencies = [
     "ipykernel>=6.29.4",
+    "pyright>=1.1.389",
 ]
 
 [tool.uv.sources]

--- a/libraries/python/skills/notebooks/uv.lock
+++ b/libraries/python/skills/notebooks/uv.lock
@@ -150,6 +150,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -372,6 +373,7 @@ requires-dist = [{ name = "events", editable = "../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -482,6 +484,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "executing"
@@ -963,6 +968,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1011,7 +1025,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1131,6 +1148,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../openai-client" },
     { name = "skill-library", editable = "../skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "prompt-toolkit"
@@ -1338,6 +1358,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1593,6 +1626,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1623,6 +1659,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1679,6 +1716,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -1704,6 +1742,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -1721,7 +1760,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ipykernel", specifier = ">=6.29.4" }]
+dev = [
+    { name = "ipykernel", specifier = ">=6.29.4" },
+    { name = "pyright", specifier = ">=1.1.389" },
+]
 
 [[package]]
 name = "sniffio"

--- a/libraries/python/skills/skill-library/.vscode/settings.json
+++ b/libraries/python/skills/skill-library/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": true,
   "search.exclude": {

--- a/libraries/python/skills/skill-library/pyproject.toml
+++ b/libraries/python/skills/skill-library/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 [tool.uv]
 package = true
 dev-dependencies = [
+    "pyright>=1.1.389",
     "pytest>=8.3.1",
     "pytest-asyncio>=0.23.8",
     "pytest-repeat>=0.9.3",

--- a/libraries/python/skills/skill-library/skill_library/assistant.py
+++ b/libraries/python/skills/skill-library/skill_library/assistant.py
@@ -62,17 +62,6 @@ class Assistant:
         # Register all skills for the assistant.
         self.skill_registry = SkillRegistry(skills, self.routine_stack) if skills else None
 
-        # If a skill registry is provided, use it to run routines. Otherwise,
-        # raise an error if someone tries to run a routine.
-        if self.skill_registry:
-            self.run_routine = self.skill_registry.run_routine_by_designation
-        else:
-
-            async def run_routine(context: RunContext, name: str, vars: dict[str, Any] | None) -> None:
-                raise ValueError("No skill registry registered for this assistant.")
-
-            self.run_routine = run_routine
-
         # Set up the assistant event queue.
         self._event_queue = asyncio.Queue()  # Async queue for events
         self._stopped = asyncio.Event()  # Event to signal when the assistant has stopped

--- a/libraries/python/skills/skill-library/skill_library/assistant.py
+++ b/libraries/python/skills/skill-library/skill_library/assistant.py
@@ -151,7 +151,7 @@ class Assistant:
             session_id=self.assistant_id,
             assistant_drive=self.drive,
             emit=self._emit,
-            run_routine=self.run_routine,
+            run_routine=self.run_routine,  # type: ignore - TODO: FIX THIS
             routine_stack=self.routine_stack,
         )
 

--- a/libraries/python/skills/skill-library/skill_library/run_context.py
+++ b/libraries/python/skills/skill-library/skill_library/run_context.py
@@ -47,7 +47,7 @@ class RunContext(ContextProtocol):
         # A "run" is a particular series of calls within a session. The initial call will
         # set the run id and all subsequent calls will use the same run id. This is useful
         # for logging, metrics, and debugging.
-        self.run_id: str = str(uuid4())
+        self.run_id: str | None = str(uuid4())
 
         # The emit function is used to send events to the event bus. The component
         # that creates this context object will be responsible for instantiating an

--- a/libraries/python/skills/skill-library/skill_library/skill_registry.py
+++ b/libraries/python/skills/skill-library/skill_library/skill_registry.py
@@ -62,14 +62,14 @@ class SkillRegistry:
         return skill.get_routine(routine_name)
 
     async def run_routine_by_designation(
-        self, context: RunContext, designation: str, vars: dict[str, Any] | None = None
+        self, context: RunContext, name: str, vars: dict[str, Any] | None = None
     ) -> Any:
         """
         Run an assistant routine by designation (<skill_name>.<routine_name>).
         """
-        routine = self.get_routine(designation)
+        routine = self.get_routine(name)
         if not routine:
-            raise ValueError(f"Routine {designation} not found.")
+            raise ValueError(f"Routine {name} not found.")
         response = await self.run_routine(context, routine, vars)
         return response
 

--- a/libraries/python/skills/skill-library/uv.lock
+++ b/libraries/python/skills/skill-library/uv.lock
@@ -142,6 +142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -355,6 +356,7 @@ requires-dist = [{ name = "events", editable = "../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -439,6 +441,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -846,6 +851,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.54.2"
 source = { registry = "https://pypi.org/simple" }
@@ -894,7 +908,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1139,6 +1156,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1377,6 +1407,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1407,6 +1440,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1449,6 +1483,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-repeat" },
@@ -1470,6 +1505,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/libraries/python/skills/skills/document-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/document-skill/.vscode/settings.json
@@ -17,7 +17,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "search.exclude": {

--- a/libraries/python/skills/skills/document-skill/document_skill/chat_drivers/draft_content.py
+++ b/libraries/python/skills/skills/document-skill/document_skill/chat_drivers/draft_content.py
@@ -64,7 +64,7 @@ async def draft_content(
             full_content = ""
             for content in paper_versions[-1].contents:
                 full_content += content.content
-            history.append_system_message("<EXISTING_CONTENT>{{content}}</EXISTING_CONTENT>", {"content": content})
+            history.append_system_message("<EXISTING_CONTENT>{{content}}</EXISTING_CONTENT>", {"content": full_content})
 
     config = ChatDriverConfig(
         openai_client=open_ai_client,

--- a/libraries/python/skills/skills/document-skill/document_skill/document_skill.py
+++ b/libraries/python/skills/skills/document-skill/document_skill/document_skill.py
@@ -154,6 +154,7 @@ class DocumentSkill(Skill):
 
         # Routine.
         decision = "[ITERATE]"
+        user_feedback: str | None = None
         while decision == "[ITERATE]":
             await document_skill.draft_outline(session_id, user_feedback=user_feedback)
             user_feedback = await ask_user("This look good?")
@@ -163,6 +164,7 @@ class DocumentSkill(Skill):
         await document_skill.draft_content(session_id)
         user_feedback = await ask_user("This look good?")
         decision = await document_skill.get_user_feedback_decision(session_id, user_feedback, outline=False)
+        content = ""
         while decision != "[QUIT]":
             content = await document_skill.draft_content(session_id, user_feedback=user_feedback, decision=decision)
             decision, user_feedback = await document_skill.get_user_feedback_decision(

--- a/libraries/python/skills/skills/document-skill/pyproject.toml
+++ b/libraries/python/skills/skills/document-skill/pyproject.toml
@@ -24,3 +24,8 @@ skill-library = { path = "../../skill-library", editable= true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/skills/skills/document-skill/uv.lock
+++ b/libraries/python/skills/skills/document-skill/uv.lock
@@ -142,6 +142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -340,6 +341,7 @@ requires-dist = [{ name = "events", editable = "../../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -412,6 +414,11 @@ dependencies = [
     { name = "skill-library" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "context", editable = "../../../context" },
@@ -419,6 +426,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../../openai-client" },
     { name = "skill-library", editable = "../../skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "email-validator"
@@ -443,6 +453,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -829,6 +842,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -877,7 +899,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1113,6 +1138,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1309,6 +1347,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1339,6 +1380,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1395,6 +1437,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/libraries/python/skills/skills/form-filler-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/form-filler-skill/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "search.exclude": {

--- a/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/artifact_helpers.py
+++ b/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/artifact_helpers.py
@@ -199,6 +199,7 @@ def get_schema_for_prompt(
 
     types_schema = schema.get("$defs", {})
     custom_types = []
+    type_name = None
     for type_name, type_info in types_schema.items():
         if f"'type': '{type_name}'" in properties:
             clean_schema = _clean_properties(type_info, [])

--- a/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/chat_drivers/update_agenda.py
+++ b/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/chat_drivers/update_agenda.py
@@ -118,6 +118,8 @@ async def generate_agenda(
     # include additional constraint instructions.
     remaining_resource = resource.remaining_units if resource.remaining_units else 0
     resource_instructions = resource.get_resource_instructions()
+    total_resource_str = ""
+    ample_time_str = ""
     if (resource_instructions != "") and (remaining_resource > 1):
         match resource.get_resource_mode():
             case ResourceConstraintMode.MAXIMUM:
@@ -135,9 +137,6 @@ async def generate_agenda(
                 )
             case _:
                 logger.error("Invalid resource mode.")
-    else:
-        total_resource_str = ""
-        ample_time_str = ""
 
     completion_args = {
         "model": "gpt-4o",

--- a/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/tests/test_integration.py
+++ b/libraries/python/skills/skills/form-filler-skill/form_filler_skill/guided_conversation/tests/test_integration.py
@@ -94,6 +94,7 @@ async def test_poem_feedback():
     await skill.conversation_init_function(context=runContext)
 
     finished = False
+    artifact = None
     while not finished:
         user_message = input("You: ")
         finished, artifact = await skill.conversation_step_function(runContext, user_message)

--- a/libraries/python/skills/skills/form-filler-skill/pyproject.toml
+++ b/libraries/python/skills/skills/form-filler-skill/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest-asyncio>=0.23.8",
     "pytest-repeat>=0.9.3",
     "ipykernel>=6.29.4",
+    "pyright>=1.1.389",
 ]
 
 [tool.uv]

--- a/libraries/python/skills/skills/form-filler-skill/uv.lock
+++ b/libraries/python/skills/skills/form-filler-skill/uv.lock
@@ -162,6 +162,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -427,6 +428,7 @@ requires-dist = [{ name = "events", editable = "../../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -483,23 +485,23 @@ wheels = [
 
 [[package]]
 name = "debugpy"
-version = "1.8.8"
+version = "1.8.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/5e/7667b95c9d7ddb25c047143a3a47685f9be2a5d3d177a85a730b22dc6e5c/debugpy-1.8.8.zip", hash = "sha256:e6355385db85cbd666be703a96ab7351bc9e6c61d694893206f8001e22aee091", size = 4928684 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/92/15b454c516c4c53cc8c03967e4be12b65a1ea36db3bb4513a7453f75c8d8/debugpy-1.8.9.zip", hash = "sha256:1339e14c7d980407248f09824d1b25ff5c5616651689f1e0f0e51bdead3ea13e", size = 4921695 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/55/6b5596ea6d5490e17abc2896f1fbe83d31205a22629805daccd30686721c/debugpy-1.8.8-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:c399023146e40ae373753a58d1be0a98bf6397fadc737b97ad612886b53df318", size = 2187057 },
-    { url = "https://files.pythonhosted.org/packages/3f/f7/c2ee07f6335c3620c1435aef2c4d3d4853f6b7fb0789aa2c52a84498ef90/debugpy-1.8.8-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09cc7b162586ea2171eea055985da2702b0723f6f907a423c9b2da5996ad67ba", size = 3139844 },
-    { url = "https://files.pythonhosted.org/packages/0d/68/01d335338b68bdebab11de573f4631c7bf0404666ccbf474621123497702/debugpy-1.8.8-cp311-cp311-win32.whl", hash = "sha256:eea8821d998ebeb02f0625dd0d76839ddde8cbf8152ebbe289dd7acf2cdc6b98", size = 5049405 },
-    { url = "https://files.pythonhosted.org/packages/22/1d/3f69460b4b8f01dace3882513de71a446eb37ee57fe2112be948fadebde8/debugpy-1.8.8-cp311-cp311-win_amd64.whl", hash = "sha256:d4483836da2a533f4b1454dffc9f668096ac0433de855f0c22cdce8c9f7e10c4", size = 5075025 },
-    { url = "https://files.pythonhosted.org/packages/c2/04/8e79824c4d9100049bda056aeaf8f2765d1325a4521a87f8bb373c977236/debugpy-1.8.8-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:0cc94186340be87b9ac5a707184ec8f36547fb66636d1029ff4f1cc020e53996", size = 2514549 },
-    { url = "https://files.pythonhosted.org/packages/a5/6b/c336d1eba1aedc9f654aefcdfe47ec41657d149f28ca1477c5f9009681c6/debugpy-1.8.8-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64674e95916e53c2e9540a056e5f489e0ad4872645399d778f7c598eacb7b7f9", size = 4229617 },
-    { url = "https://files.pythonhosted.org/packages/63/9c/d9276c41e9e14164b31bcba789c87a355c091d0fc2d4e4e36a4881c9aa54/debugpy-1.8.8-cp312-cp312-win32.whl", hash = "sha256:5c6e885dbf12015aed73770f29dec7023cb310d0dc2ba8bfbeb5c8e43f80edc9", size = 5167033 },
-    { url = "https://files.pythonhosted.org/packages/6d/1c/fd4bc22196b2d0defaa9f644ea4d676d0cb53b6434091b5fa2d4e49c85f2/debugpy-1.8.8-cp312-cp312-win_amd64.whl", hash = "sha256:19ffbd84e757a6ca0113574d1bf5a2298b3947320a3e9d7d8dc3377f02d9f864", size = 5209968 },
-    { url = "https://files.pythonhosted.org/packages/90/45/6745f342bbf41bde7eb5dbf5567b794a4a5498a7a729146cb3101b875b30/debugpy-1.8.8-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:705cd123a773d184860ed8dae99becd879dfec361098edbefb5fc0d3683eb804", size = 2499523 },
-    { url = "https://files.pythonhosted.org/packages/5c/39/0374610062a384648db9b7b315d0c906facf23613bfd19527135a7c0a420/debugpy-1.8.8-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:890fd16803f50aa9cb1a9b9b25b5ec321656dd6b78157c74283de241993d086f", size = 4218219 },
-    { url = "https://files.pythonhosted.org/packages/cc/19/5b8a68eb9bbafd6bfd27ba0ed93d411f3fd50935ecdd2df242de2110a7c9/debugpy-1.8.8-cp313-cp313-win32.whl", hash = "sha256:90244598214bbe704aa47556ec591d2f9869ff9e042e301a2859c57106649add", size = 5171845 },
-    { url = "https://files.pythonhosted.org/packages/cd/04/7381dab68e40ca877d5beffc25ad1a0d3d2557cf7465405435fac9e27ef5/debugpy-1.8.8-cp313-cp313-win_amd64.whl", hash = "sha256:4b93e4832fd4a759a0c465c967214ed0c8a6e8914bced63a28ddb0dd8c5f078b", size = 5206890 },
-    { url = "https://files.pythonhosted.org/packages/03/99/ec2190d03df5dbd610418919bd1c3d8e6f61d0a97894e11ade6d3260cfb8/debugpy-1.8.8-py2.py3-none-any.whl", hash = "sha256:ec684553aba5b4066d4de510859922419febc710df7bba04fe9e7ef3de15d34f", size = 5157124 },
+    { url = "https://files.pythonhosted.org/packages/f7/bf/c41b688ad490d644b3bcca505a87ea58ec0442234def9a641ba62dce9c11/debugpy-1.8.9-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:b74a49753e21e33e7cf030883a92fa607bddc4ede1aa4145172debc637780040", size = 2179080 },
+    { url = "https://files.pythonhosted.org/packages/f4/dd/e9de11423db7bde62469fbd932243c64f66d6d87924976f49ec336415522/debugpy-1.8.9-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62d22dacdb0e296966d7d74a7141aaab4bec123fa43d1a35ddcb39bf9fd29d70", size = 3137893 },
+    { url = "https://files.pythonhosted.org/packages/2c/bf/e1f2c81220591728f35585b4abd67e71e9b39b3cb983f428b23d4ca6c22e/debugpy-1.8.9-cp311-cp311-win32.whl", hash = "sha256:8138efff315cd09b8dcd14226a21afda4ca582284bf4215126d87342bba1cc66", size = 5042644 },
+    { url = "https://files.pythonhosted.org/packages/96/20/a407252954fd2812771e4ea3ab523f73889fd5027e305dec5ee4f0af149a/debugpy-1.8.9-cp311-cp311-win_amd64.whl", hash = "sha256:ff54ef77ad9f5c425398efb150239f6fe8e20c53ae2f68367eba7ece1e96226d", size = 5066943 },
+    { url = "https://files.pythonhosted.org/packages/da/ab/1420baf8404d2b499349a44de5037133e06d489009032ce016fedb66eea1/debugpy-1.8.9-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:957363d9a7a6612a37458d9a15e72d03a635047f946e5fceee74b50d52a9c8e2", size = 2504180 },
+    { url = "https://files.pythonhosted.org/packages/58/ec/e0f88c6764314bda7887274e0b980812709b3d6363dcae124a49a9ceaa3c/debugpy-1.8.9-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e565fc54b680292b418bb809f1386f17081d1346dca9a871bf69a8ac4071afe", size = 4224563 },
+    { url = "https://files.pythonhosted.org/packages/dd/49/d9ea004ee2e4531d2b528841689ee2ba01c6a4b58840efd15e57dd866a86/debugpy-1.8.9-cp312-cp312-win32.whl", hash = "sha256:3e59842d6c4569c65ceb3751075ff8d7e6a6ada209ceca6308c9bde932bcef11", size = 5163641 },
+    { url = "https://files.pythonhosted.org/packages/b1/63/c8b0718024c1187a446316037680e1564bf063c6665c815f17b42c244aba/debugpy-1.8.9-cp312-cp312-win_amd64.whl", hash = "sha256:66eeae42f3137eb428ea3a86d4a55f28da9bd5a4a3d369ba95ecc3a92c1bba53", size = 5203862 },
+    { url = "https://files.pythonhosted.org/packages/cc/8d/eb12dcb977a2d166aac6614e60daddd1eef72881a0343717d7deb0d4868c/debugpy-1.8.9-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:957ecffff80d47cafa9b6545de9e016ae8c9547c98a538ee96ab5947115fb3dd", size = 2489077 },
+    { url = "https://files.pythonhosted.org/packages/87/2b/3b7a00d8d2bb891cfa33240575c2d5fc3fa6e0bc75567f4ece59b9d3d6ea/debugpy-1.8.9-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1efbb3ff61487e2c16b3e033bc8595aea578222c08aaf3c4bf0f93fadbd662ee", size = 4219198 },
+    { url = "https://files.pythonhosted.org/packages/5f/a1/f489026a65fabfff8c73bd51b880c130d636e02b1847564141fe3957d94f/debugpy-1.8.9-cp313-cp313-win32.whl", hash = "sha256:7c4d65d03bee875bcb211c76c1d8f10f600c305dbd734beaed4077e902606fee", size = 5163014 },
+    { url = "https://files.pythonhosted.org/packages/e6/84/6070908dd163121358eb9d76fcc94f05bc99d2f89a85fe1b86167bc34ec6/debugpy-1.8.9-cp313-cp313-win_amd64.whl", hash = "sha256:e46b420dc1bea64e5bbedd678148be512442bc589b0111bd799367cde051e71a", size = 5203529 },
+    { url = "https://files.pythonhosted.org/packages/2d/23/3f5804202da11c950dc0caae4a62d0c9aadabdb2daeb5f7aa09838647b5d/debugpy-1.8.9-py2.py3-none-any.whl", hash = "sha256:cc37a6c9987ad743d9c3a14fa1b1a14b7e4e6041f9dd0c8abf8895fe7a97b899", size = 5166094 },
 ]
 
 [[package]]
@@ -561,6 +563,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "executing"
@@ -629,6 +634,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-repeat" },
@@ -647,6 +653,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.4" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -1160,6 +1167,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1208,7 +1224,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1548,6 +1567,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1842,6 +1874,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1872,6 +1907,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1928,6 +1964,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -2000,20 +2037,20 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.4.1"
+version = "6.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/66/398ac7167f1c7835406888a386f6d0d26ee5dbf197d8a571300be57662d3/tornado-6.4.1.tar.gz", hash = "sha256:92d3ab53183d8c50f8204a51e6f91d18a15d5ef261e84d452800d4ff6fc504e9", size = 500623 }
+sdist = { url = "https://files.pythonhosted.org/packages/59/45/a0daf161f7d6f36c3ea5fc0c2de619746cc3dd4c76402e9db545bd920f63/tornado-6.4.2.tar.gz", hash = "sha256:92bad5b4746e9879fd7bf1eb21dce4e3fc5128d71601f80005afa39237ad620b", size = 501135 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/d9/c33be3c1a7564f7d42d87a8d186371a75fd142097076767a5c27da941fef/tornado-6.4.1-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:163b0aafc8e23d8cdc3c9dfb24c5368af84a81e3364745ccb4427669bf84aec8", size = 435924 },
-    { url = "https://files.pythonhosted.org/packages/2e/0f/721e113a2fac2f1d7d124b3279a1da4c77622e104084f56119875019ffab/tornado-6.4.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6d5ce3437e18a2b66fbadb183c1d3364fb03f2be71299e7d10dbeeb69f4b2a14", size = 433883 },
-    { url = "https://files.pythonhosted.org/packages/13/cf/786b8f1e6fe1c7c675e79657448178ad65e41c1c9765ef82e7f6f765c4c5/tornado-6.4.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2e20b9113cd7293f164dc46fffb13535266e713cdb87bd2d15ddb336e96cfc4", size = 437224 },
-    { url = "https://files.pythonhosted.org/packages/e4/8e/a6ce4b8d5935558828b0f30f3afcb2d980566718837b3365d98e34f6067e/tornado-6.4.1-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ae50a504a740365267b2a8d1a90c9fbc86b780a39170feca9bcc1787ff80842", size = 436597 },
-    { url = "https://files.pythonhosted.org/packages/22/d4/54f9d12668b58336bd30defe0307e6c61589a3e687b05c366f804b7faaf0/tornado-6.4.1-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:613bf4ddf5c7a95509218b149b555621497a6cc0d46ac341b30bd9ec19eac7f3", size = 436797 },
-    { url = "https://files.pythonhosted.org/packages/cf/3f/2c792e7afa7dd8b24fad7a2ed3c2f24a5ec5110c7b43a64cb6095cc106b8/tornado-6.4.1-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:25486eb223babe3eed4b8aecbac33b37e3dd6d776bc730ca14e1bf93888b979f", size = 437516 },
-    { url = "https://files.pythonhosted.org/packages/71/63/c8fc62745e669ac9009044b889fc531b6f88ac0f5f183cac79eaa950bb23/tornado-6.4.1-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:454db8a7ecfcf2ff6042dde58404164d969b6f5d58b926da15e6b23817950fc4", size = 436958 },
-    { url = "https://files.pythonhosted.org/packages/94/d4/f8ac1f5bd22c15fad3b527e025ce219bd526acdbd903f52053df2baecc8b/tornado-6.4.1-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a02a08cc7a9314b006f653ce40483b9b3c12cda222d6a46d4ac63bb6c9057698", size = 436882 },
-    { url = "https://files.pythonhosted.org/packages/4b/3e/a8124c21cc0bbf144d7903d2a0cadab15cadaf683fa39a0f92bc567f0d4d/tornado-6.4.1-cp38-abi3-win32.whl", hash = "sha256:d9a566c40b89757c9aa8e6f032bcdb8ca8795d7c1a9762910c722b1635c9de4d", size = 438092 },
-    { url = "https://files.pythonhosted.org/packages/d9/2f/3f2f05e84a7aff787a96d5fb06821323feb370fe0baed4db6ea7b1088f32/tornado-6.4.1-cp38-abi3-win_amd64.whl", hash = "sha256:b24b8982ed444378d7f21d563f4180a2de31ced9d8d84443907a0a64da2072e7", size = 438532 },
+    { url = "https://files.pythonhosted.org/packages/26/7e/71f604d8cea1b58f82ba3590290b66da1e72d840aeb37e0d5f7291bd30db/tornado-6.4.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e828cce1123e9e44ae2a50a9de3055497ab1d0aeb440c5ac23064d9e44880da1", size = 436299 },
+    { url = "https://files.pythonhosted.org/packages/96/44/87543a3b99016d0bf54fdaab30d24bf0af2e848f1d13d34a3a5380aabe16/tornado-6.4.2-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:072ce12ada169c5b00b7d92a99ba089447ccc993ea2143c9ede887e0937aa803", size = 434253 },
+    { url = "https://files.pythonhosted.org/packages/cb/fb/fdf679b4ce51bcb7210801ef4f11fdac96e9885daa402861751353beea6e/tornado-6.4.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a017d239bd1bb0919f72af256a970624241f070496635784d9bf0db640d3fec", size = 437602 },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/e31aeffffc22b475a64dbeb273026a21b5b566f74dee48742817626c47dc/tornado-6.4.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c36e62ce8f63409301537222faffcef7dfc5284f27eec227389f2ad11b09d946", size = 436972 },
+    { url = "https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bca9eb02196e789c9cb5c3c7c0f04fb447dc2adffd95265b2c7223a8a615ccbf", size = 437173 },
+    { url = "https://files.pythonhosted.org/packages/79/5e/be4fb0d1684eb822c9a62fb18a3e44a06188f78aa466b2ad991d2ee31104/tornado-6.4.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:304463bd0772442ff4d0f5149c6f1c2135a1fae045adf070821c6cdc76980634", size = 437892 },
+    { url = "https://files.pythonhosted.org/packages/f5/33/4f91fdd94ea36e1d796147003b490fe60a0215ac5737b6f9c65e160d4fe0/tornado-6.4.2-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:c82c46813ba483a385ab2a99caeaedf92585a1f90defb5693351fa7e4ea0bf73", size = 437334 },
+    { url = "https://files.pythonhosted.org/packages/2b/ae/c1b22d4524b0e10da2f29a176fb2890386f7bd1f63aacf186444873a88a0/tornado-6.4.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:932d195ca9015956fa502c6b56af9eb06106140d844a335590c1ec7f5277d10c", size = 437261 },
+    { url = "https://files.pythonhosted.org/packages/b5/25/36dbd49ab6d179bcfc4c6c093a51795a4f3bed380543a8242ac3517a1751/tornado-6.4.2-cp38-abi3-win32.whl", hash = "sha256:2876cef82e6c5978fde1e0d5b1f919d756968d5b4282418f3146b79b58556482", size = 438463 },
+    { url = "https://files.pythonhosted.org/packages/61/cc/58b1adeb1bb46228442081e746fcdbc4540905c87e8add7c277540934edb/tornado-6.4.2-cp38-abi3-win_amd64.whl", hash = "sha256:908b71bf3ff37d81073356a5fadcc660eb10c1476ee6e2725588626ce7e5ca38", size = 438907 },
 ]
 
 [[package]]

--- a/libraries/python/skills/skills/posix-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/posix-skill/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.cwd": "${workspaceFolder}",
   "search.exclude": {

--- a/libraries/python/skills/skills/posix-skill/pyproject.toml
+++ b/libraries/python/skills/skills/posix-skill/pyproject.toml
@@ -25,3 +25,8 @@ openai-client = { path = "../../../openai-client", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/skills/skills/posix-skill/uv.lock
+++ b/libraries/python/skills/skills/posix-skill/uv.lock
@@ -142,6 +142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -340,6 +341,7 @@ requires-dist = [{ name = "events", editable = "../../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -424,6 +426,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -810,6 +815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,7 +872,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -941,6 +958,11 @@ dependencies = [
     { name = "skill-library" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "context", editable = "../../../context" },
@@ -948,6 +970,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../../openai-client" },
     { name = "skill-library", editable = "../../skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "propcache"
@@ -1110,6 +1135,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1309,6 +1347,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1339,6 +1380,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1395,6 +1437,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/libraries/python/skills/skills/prospector-skill/.vscode/settings.json
+++ b/libraries/python/skills/skills/prospector-skill/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": false,
   "search.exclude": {

--- a/libraries/python/skills/skills/prospector-skill/pyproject.toml
+++ b/libraries/python/skills/skills/prospector-skill/pyproject.toml
@@ -25,3 +25,8 @@ skill-library = { path = "../../skill-library", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/skills/skills/prospector-skill/uv.lock
+++ b/libraries/python/skills/skills/prospector-skill/uv.lock
@@ -142,6 +142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -340,6 +341,7 @@ requires-dist = [{ name = "events", editable = "../../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -424,6 +426,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -810,6 +815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,7 +872,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -998,6 +1015,11 @@ dependencies = [
     { name = "skill-library" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "context", editable = "../../../context" },
@@ -1005,6 +1027,9 @@ requires-dist = [
     { name = "openai-client", editable = "../../../openai-client" },
     { name = "skill-library", editable = "../../skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "pycparser"
@@ -1110,6 +1135,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1309,6 +1347,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1339,6 +1380,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1395,6 +1437,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },

--- a/libraries/python/skills/skills/skill-template/.vscode/settings.json
+++ b/libraries/python/skills/skills/skill-template/.vscode/settings.json
@@ -18,7 +18,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.testing.pytestEnabled": false,
   "search.exclude": {

--- a/libraries/python/skills/skills/skill-template/pyproject.toml
+++ b/libraries/python/skills/skills/skill-template/pyproject.toml
@@ -23,3 +23,8 @@ skill-library = { path = "../../skill-library", editable = true }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pyright>=1.1.389",
+]

--- a/libraries/python/skills/skills/skill-template/uv.lock
+++ b/libraries/python/skills/skills/skill-template/uv.lock
@@ -142,6 +142,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -340,6 +341,7 @@ requires-dist = [{ name = "events", editable = "../../../events" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -424,6 +426,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = ">=2.6.1" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "fastapi"
@@ -810,6 +815,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -858,7 +872,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.3.3" }]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.3" },
+]
 
 [[package]]
 name = "packaging"
@@ -1094,6 +1111,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1290,6 +1320,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1320,6 +1353,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1376,6 +1410,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.23.8" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
@@ -1687,6 +1722,11 @@ dependencies = [
     { name = "skill-library" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "context", editable = "../../../context" },
@@ -1694,3 +1734,6 @@ requires-dist = [
     { name = "openai-client", specifier = ">=0.1.0" },
     { name = "skill-library", editable = "../../skill-library" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]

--- a/tools/makefiles/python.mk
+++ b/tools/makefiles/python.mk
@@ -4,7 +4,7 @@ include $(mkfile_dir)/shell.mk
 .DEFAULT_GOAL ?= install
 
 ifdef UV_PROJECT_DIR
-uv_project_args = --project $(UV_PROJECT_DIR)
+uv_project_args = --directory $(UV_PROJECT_DIR)
 venv_dir = $(UV_PROJECT_DIR)/.venv
 else
 venv_dir = .venv
@@ -38,6 +38,20 @@ format:
 	uvx ruff format --no-cache .
 
 ifneq ($(findstring pytest,$(if $(shell $(call command_exists,uv) $(stderr_redirect_null)),$(shell uv tree --depth 1 $(stderr_redirect_null)),)),)
+PYTEST_EXISTS=true
+endif
+ifneq ($(findstring pyright,$(if $(shell $(call command_exists,uv) $(stderr_redirect_null)),$(shell uv tree --depth 1 $(stderr_redirect_null)),)),)
+PYRIGHT_EXISTS=true
+endif
+
+ifeq ($(PYRIGHT_EXISTS),true)
+.PHONY: type-check test
+test: type-check
+type-check:
+	uv run $(uv_project_args) $(UV_RUN_ARGS) pyright $(PYRIGHT_ARGS)
+endif
+
+ifeq ($(PYTEST_EXISTS),true)
 .PHONY: test
 test:
 	uv run $(uv_project_args) $(UV_RUN_ARGS) pytest $(PYTEST_ARGS)

--- a/tools/makefiles/recursive.mk
+++ b/tools/makefiles/recursive.mk
@@ -14,6 +14,8 @@ ifndef IS_RECURSIVE_MAKE
 # make with VERBOSE=1 to print all outputs of recursive makes
 VERBOSE ?= 0
 
+RECURSIVE_TARGETS = clean install test format lint type-check
+
 # You can pass in a list of files or directories to retain when running `clean/git-clean`
 # ex: make clean GIT_CLEAN_RETAIN=".env .data"
 # As always with make, you can also set this as an environment variable
@@ -63,11 +65,11 @@ else
 	fi
 endif
 
-.PHONY: clean install test format lint $(MAKE_DIRS)
+.PHONY: $(RECURSIVE_TARGETS) $(MAKE_DIRS)
 
 clean: git-clean
 
-clean install test format lint: .clean-error-log $(MAKE_DIRS) .print-error-log
+$(RECURSIVE_TARGETS): .clean-error-log $(MAKE_DIRS) .print-error-log
 
 $(MAKE_DIRS):
 ifdef FAIL_ON_ERROR

--- a/workbench-app/Makefile
+++ b/workbench-app/Makefile
@@ -10,8 +10,8 @@ clean:
 install:
 	pnpm install
 
-.PHONY: test
-test: install
+.PHONY: test type-check
+test type-check: install
 	pnpm run type-check
 
 .PHONY: format

--- a/workbench-service/.vscode/settings.json
+++ b/workbench-service/.vscode/settings.json
@@ -32,7 +32,7 @@
   "python.analysis.diagnosticMode": "workspace",
   "python.analysis.fixAll": ["source.unusedImports"],
   "python.analysis.inlayHints.functionReturnTypes": true,
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "standard",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
   "python.testing.pytestEnabled": true,
   "python.testing.cwd": "${workspaceFolder}",

--- a/workbench-service/pyproject.toml
+++ b/workbench-service/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 package = true
 dev-dependencies = [
     "asgi-lifespan>=2.1.0",
+    "pyright>=1.1.389",
     "pytest>=7.4.3",
     "pytest-asyncio>=0.23.5.post1",
     "pytest-docker>=3.1.1",

--- a/workbench-service/uv.lock
+++ b/workbench-service/uv.lock
@@ -858,6 +858,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openai"
 version = "1.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1018,6 +1027,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.389"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/4e/9a5ab8745e7606b88c2c7ca223449ac9d82a71fd5e31df47b453f2cb39a1/pyright-1.1.389.tar.gz", hash = "sha256:716bf8cc174ab8b4dcf6828c3298cac05c5ed775dda9910106a5dcfe4c7fe220", size = 21940 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/26/c288cabf8cfc5a27e1aa9e5029b7682c0f920b8074f45d22bf844314d66a/pyright-1.1.389-py3-none-any.whl", hash = "sha256:41e9620bba9254406dc1f621a88ceab5a88af4c826feb4f614d95691ed243a60", size = 18581 },
 ]
 
 [[package]]
@@ -1282,6 +1304,9 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = "~=0.115.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
+
 [[package]]
 name = "semantic-workbench-assistant"
 version = "0.1.0"
@@ -1312,6 +1337,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-httpx", specifier = ">=0.30.0" },
@@ -1349,6 +1375,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "asgi-lifespan" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-docker" },
@@ -1385,6 +1412,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "asgi-lifespan", specifier = ">=2.1.0" },
+    { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=7.4.3" },
     { name = "pytest-asyncio", specifier = ">=0.23.5.post1" },
     { name = "pytest-docker", specifier = ">=3.1.1" },


### PR DESCRIPTION
To run python type checking at the command line for dev-time and PR validation-time.

Switches from "basic" to "standard" validation for Pylance in vscode, to match the default `pyright` level

Additionally, fixes some type errors found in various projects.