### PR TITLE
fix Explorer handling of reasoning model responses and adds option to only respond to at mentions

### DIFF
--- a/assistants/explorer-assistant/assistant/config.py
+++ b/assistants/explorer-assistant/assistant/config.py
@@ -143,6 +143,14 @@ class AssistantConfigModel(BaseModel):
         " context of our conversation. Where would you like to start?"
     )
 
+    only_respond_to_mentions: Annotated[
+        bool,
+        Field(
+            title="Only Respond to @Mentions",
+            description="Only respond to messages that @mention the assistant.",
+        ),
+    ] = False
+
     high_token_usage_warning: Annotated[
         HighTokenUsageWarning,
         Field(

--- a/assistants/explorer-assistant/assistant/response/response_openai.py
+++ b/assistants/explorer-assistant/assistant/response/response_openai.py
@@ -127,6 +127,8 @@ class OpenAIResponseProvider(ResponseProvider):
                         max_completion_tokens=self.request_config.response_tokens,
                     )
 
+                    response_result.content = completion.choices[0].message.content
+
                 elif self.assistant_config.extensions_config.artifacts.enabled:
                     response = await self.artifacts_extension.get_openai_completion_response(
                         client,

--- a/libraries/python/skills/skill-library/.vscode/settings.json
+++ b/libraries/python/skills/skill-library/.vscode/settings.json
@@ -53,8 +53,12 @@
     "uv.lock"
   ],
   "cSpell.words": [
+    "addopts",
+    "asctime",
+    "asyncio",
     "dotenv",
     "httpx",
+    "levelname",
     "metadrive",
     "openai",
     "pydantic",
@@ -63,6 +67,7 @@
     "pytest",
     "runtimes",
     "subdrive",
+    "testpaths",
     "tiktoken"
   ],
   "python.testing.pytestArgs": ["skill_library"],


### PR DESCRIPTION
* Prior change neglected to assign completion response content to assistant response, so it said "no response" despite having one visible in debug - this fixes the issue
* Adds an option that allows the assistant to be configured to only respond to at mentions, which is useful for putting multiple instances of the assistant in the same conversation and choose, per turn, which one(s) you want to respond