### PR TITLE
Increase memory available for app build

### DIFF
--- a/workbench-app/Dockerfile
+++ b/workbench-app/Dockerfile
@@ -24,7 +24,7 @@ ENV VITE_SEMANTIC_WORKBENCH_AUTHORITY=${VITE_SEMANTIC_WORKBENCH_AUTHORITY}
 ENV VITE_SEMANTIC_WORKBENCH_CLIENT_ID=${VITE_SEMANTIC_WORKBENCH_CLIENT_ID}
 
 # Build the application
-RUN pnpm run build
+RUN NODE_OPTIONS=--max-old-space-size=4096 pnpm run build
 
 # Stage 2: Serve the app with Nginx
 FROM nginx:alpine


### PR DESCRIPTION
Frontend dockerization is failing with 

> FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory

Testing various values, looks like the frontend build requires ~3100MB of memory. 
The PR grants 4GB to be on the safe side.