### PR TITLE
Add text_list and currency form field types

### DIFF
--- a/assistants/prospector-assistant/assistant/form_fill_extension/state.py
+++ b/assistants/prospector-assistant/assistant/form_fill_extension/state.py
@@ -13,6 +13,8 @@ from .inspector import FileStateInspector
 
 class FieldType(StrEnum):
     text = "text"
+    text_list = "text_list"
+    currency = "currency"
     date = "date"
     signature = "signature"
     multiple_choice = "multiple_choice"


### PR DESCRIPTION
To better handle lists of information, like a list of addresses, or medications, for example

And for values that are expected to be currency