### PR TITLE
Separate lock target from install

### DIFF
--- a/tools/makefiles/python.mk
+++ b/tools/makefiles/python.mk
@@ -10,8 +10,9 @@ else
 venv_dir = .venv
 endif
 
-UV_SYNC_ARGS ?= --all-extras
-UV_RUN_ARGS ?= --all-extras --locked
+UV_SYNC_INSTALL_ARGS ?= --all-extras --frozen
+UV_SYNC_LOCK_ARGS ?= --all-extras
+UV_RUN_ARGS ?= --all-extras --frozen
 
 PYTEST_ARGS ?= --color=yes
 
@@ -19,11 +20,11 @@ PYTEST_ARGS ?= --color=yes
 
 .PHONY: install
 install:
-	uv sync $(uv_project_args) $(UV_SYNC_ARGS)
+	uv sync $(uv_project_args) $(UV_SYNC_INSTALL_ARGS)
 
 .PHONY: lock
 lock:
-	uv lock $(uv_project_args) $(UV_LOCK_ARGS)
+	uv sync $(uv_project_args) $(UV_SYNC_LOCK_ARGS)
 
 .PHONY: clean
 clean:

--- a/tools/makefiles/recursive.mk
+++ b/tools/makefiles/recursive.mk
@@ -14,7 +14,7 @@ ifndef IS_RECURSIVE_MAKE
 # make with VERBOSE=1 to print all outputs of recursive makes
 VERBOSE ?= 0
 
-RECURSIVE_TARGETS = clean install test format lint type-check
+RECURSIVE_TARGETS = clean install test format lint type-check lock
 
 # You can pass in a list of files or directories to retain when running `clean/git-clean`
 # ex: make clean GIT_CLEAN_RETAIN=".env .data"


### PR DESCRIPTION
To avoid updating the lock, and dependencies, when you're just trying to install.