### PR TITLE
When using Aspire locally always use the same port, without proxying

### DIFF
--- a/aspire-orchestrator/Aspire.AppHost/Program.cs
+++ b/aspire-orchestrator/Aspire.AppHost/Program.cs
@@ -68,7 +68,8 @@ internal static class Program
         // When running locally
         if (!builder.ExecutionContext.IsPublishMode)
         {
-            workbenchApp.WithHttpsEndpoint(env: "PORT");
+            if (!int.TryParse(builder.Configuration["Workbench:AppPort"], out var appPort)) { appPort = 4000; }
+            workbenchApp.WithHttpsEndpoint(port: appPort, env: "PORT", isProxied: false);
         }
 
         return builder;

--- a/aspire-orchestrator/Aspire.AppHost/appsettings.json
+++ b/aspire-orchestrator/Aspire.AppHost/appsettings.json
@@ -6,8 +6,14 @@
       "Aspire.Hosting.Dcp": "Warning"
     }
   },
+  "Workbench": {
+    // Used only when running Aspire locally, ie not in the cloud
+    // Port 4000 is the default port used also when not using Aspire.
+    // Using the same port allows to keep cookies and other local settings.
+    "AppPort": 4000
+  },
   "EntraID": {
-    "ClientId": "22cb77c3-ca98-4a26-b4db-ac4dcecba690",
-    "Authority": "https://login.microsoftonline.com/common"
+    "Authority": "https://login.microsoftonline.com/common",
+    "ClientId": "22cb77c3-ca98-4a26-b4db-ac4dcecba690"
   }
 }


### PR DESCRIPTION
Aspire by default randomizes ports, however this means that cookies from a previous session most likely don't work, in which case the workbench show the set of initial banners and asks to sign in, every time.

The PR changes this behavior on localhost, to always use port 4000 (assuming it's free), similarly to how the app runs without Aspire.