### PR TITLE
First version of mcp-tunnel

### DIFF
--- a/assistants/codespace-assistant/uv.lock
+++ b/assistants/codespace-assistant/uv.lock
@@ -773,15 +773,6 @@ wheels = [
 ]
 
 [[package]]
-name = "iniconfig"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-]
-
-[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -949,7 +940,6 @@ source = { editable = "../../libraries/python/mcp-extensions" }
 dependencies = [
     { name = "deepmerge" },
     { name = "mcp" },
-    { name = "pytest-asyncio" },
 ]
 
 [package.optional-dependencies]
@@ -962,13 +952,13 @@ requires-dist = [
     { name = "deepmerge", specifier = ">=2.0" },
     { name = "mcp", specifier = ">=1.2.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.63.2" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [[package]]
@@ -1212,15 +1202,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
-]
-
-[[package]]
 name = "portalocker"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1432,33 +1413,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
-]
-
-[[package]]
-name = "pytest"
-version = "8.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "0.25.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a8/ecbc8ede70921dd2f544ab1cadd3ff3bf842af27f87bbdea774c7baa1d38/pytest_asyncio-0.25.3.tar.gz", hash = "sha256:fc1da2cf9f125ada7e710b4ddad05518d4cee187ae9412e9ac9271003497f07a", size = 54239 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/17/3493c5624e48fd97156ebaec380dcaafee9506d7e2c46218ceebbb57d7de/pytest_asyncio-0.25.3-py3-none-any.whl", hash = "sha256:9e89518e0f9bd08928f97a3482fdc4e244df17529460bc038291ccaf8f85c7c3", size = 19467 },
 ]
 
 [[package]]

--- a/libraries/python/assistant-extensions/uv.lock
+++ b/libraries/python/assistant-extensions/uv.lock
@@ -897,7 +897,6 @@ source = { editable = "../mcp-extensions" }
 dependencies = [
     { name = "deepmerge" },
     { name = "mcp" },
-    { name = "pytest-asyncio" },
 ]
 
 [package.optional-dependencies]
@@ -910,13 +909,13 @@ requires-dist = [
     { name = "deepmerge", specifier = ">=2.0" },
     { name = "mcp", specifier = ">=1.2.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.63.2" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [[package]]

--- a/libraries/python/mcp-extensions/pyproject.toml
+++ b/libraries/python/mcp-extensions/pyproject.toml
@@ -7,8 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "deepmerge>=2.0",
- "mcp>=1.2.1",
- "pytest-asyncio>=0.25.3",
+    "mcp>=1.2.1",
 ]
 
 [project.optional-dependencies]
@@ -23,5 +22,4 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["pyright>=1.1.389", "pytest>=8.3.1"]
-
+dev = ["pyright>=1.1.389", "pytest>=8.3.1", "pytest-asyncio>=0.25.3"]

--- a/libraries/python/mcp-extensions/uv.lock
+++ b/libraries/python/mcp-extensions/uv.lock
@@ -209,7 +209,6 @@ source = { editable = "." }
 dependencies = [
     { name = "deepmerge" },
     { name = "mcp" },
-    { name = "pytest-asyncio" },
 ]
 
 [package.optional-dependencies]
@@ -221,6 +220,7 @@ openai = [
 dev = [
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -228,13 +228,13 @@ requires-dist = [
     { name = "deepmerge", specifier = ">=2.0" },
     { name = "mcp", specifier = ">=1.2.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.63.2" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pyright", specifier = ">=1.1.389" },
     { name = "pytest", specifier = ">=8.3.1" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
 ]
 
 [[package]]

--- a/libraries/python/mcp-tunnel/.vscode/settings.json
+++ b/libraries/python/mcp-tunnel/.vscode/settings.json
@@ -1,0 +1,57 @@
+{
+  "editor.bracketPairColorization.enabled": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "explicit",
+    "source.fixAll": "explicit"
+  },
+  "editor.guides.bracketPairs": "active",
+  "editor.formatOnPaste": true,
+  "editor.formatOnType": true,
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "python.analysis.autoFormatStrings": true,
+  "python.analysis.autoImportCompletions": true,
+  "python.analysis.diagnosticMode": "workspace",
+  "python.analysis.fixAll": [
+    "source.unusedImports"
+  ],
+  "python.analysis.inlayHints.functionReturnTypes": true,
+  "python.analysis.typeCheckingMode": "standard",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
+  "python.testing.pytestEnabled": false,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit",
+      "source.unusedImports": "explicit",
+      "source.organizeImports": "explicit",
+      "source.formatDocument": "explicit"
+    }
+  },
+  "ruff.nativeServer": "on",
+  "search.exclude": {
+    "**/.venv": true,
+    "**/.data": true,
+    "**/__pycache__": true
+  },
+  // For use with optional extension: "streetsidesoftware.code-spell-checker"
+  "cSpell.ignorePaths": [
+    ".venv",
+    "node_modules",
+    "package-lock.json",
+    "settings.json",
+    "uv.lock"
+  ],
+  "cSpell.words": [
+    "asyncio",
+    "deepmerge",
+    "fastmcp",
+    "interoperating",
+    "Lifecycles",
+    "pydantic",
+    "pyright",
+    "pytest"
+  ]
+}

--- a/libraries/python/mcp-tunnel/Makefile
+++ b/libraries/python/mcp-tunnel/Makefile
@@ -1,0 +1,2 @@
+repo_root = $(shell git rev-parse --show-toplevel)
+include $(repo_root)/tools/makefiles/python.mk

--- a/libraries/python/mcp-tunnel/README.md
+++ b/libraries/python/mcp-tunnel/README.md
@@ -1,0 +1,103 @@
+# MCP Tunnel
+
+A command-line tool for managing secure tunnels to local Model Context Protocol (MCP) servers.
+
+## Overview
+
+MCP Tunnel simplifies the process of exposing locally running MCP servers to the internet through secure tunnels. This enables AI assistants like Codespace assistant to connect to your local MCP servers, allowing them to access local resources, files, and functionality.
+
+The tool uses Microsoft's DevTunnel service to create secure tunnels from the internet to your local machine. It can manage multiple tunnels simultaneously and generates the necessary configuration files for connecting your Codespace assistant to these tunnels.
+
+## Prerequisites
+
+- Python 3.11 or higher
+- [Microsoft DevTunnel CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started) installed and available in your PATH
+- A Microsoft account (to log in to DevTunnel)
+
+## Installation
+
+Install MCP Tunnel using make from the `mcp-tunnel` directory:
+
+```bash
+make install
+```
+
+## Usage
+
+### Basic Usage
+
+Start tunnels for default MCP servers (vscode on port 6010 and office on port 25566):
+
+```bash
+mcp-tunnel
+```
+
+### Custom Servers
+
+Specify custom server names and ports:
+
+```bash
+mcp-tunnel --servers "myserver:8080,anotherserver:9000"
+```
+
+### Output
+
+When you run MCP Tunnel, it will:
+
+1. Check if DevTunnel CLI is installed and you're logged in
+2. Create tunnels for each specified server
+3. Start tunnel processes and display their output with color-coding
+4. Generate a configuration file at `~/.mcp-tunnel/config.yaml`
+5. Keep tunnels running until you press Ctrl+C
+
+Example output:
+
+```
+DevTunnel CLI detected and user is logged in
+Starting tunnels for servers: vscode, office
+Starting tunnel for vscode on port 6010...
+Starting tunnel for office on port 25566...
+[vscode] Tunnel vscode-a1b2c3 is online and ready to use
+[vscode] Using tunnel URL: https://a1b2c3d4-6010.usw2.devtunnels.ms
+[office] Tunnel office-a1b2c3 is online and ready to use
+[office] Using tunnel URL: https://e5f6g7h8-25566.usw2.devtunnels.ms
+
+Config file written to: /home/user/.mcp-tunnel/config.yaml
+
+All tunnels started. Press Ctrl+C to stop all tunnels.
+```
+
+## Configuration
+
+MCP Tunnel generates a configuration file at `~/.mcp-tunnel/config.yaml` that can be used to connect your AI assistant to the tunnels. The configuration includes:
+
+- SSE endpoints for each tunnel
+- Authentication headers
+
+You can use this configuration with the Codespace assistant by importing it from the Assistant Configuration screen.
+
+## Troubleshooting
+
+### DevTunnel CLI Not Found
+
+If you see an error about the DevTunnel CLI not being found:
+
+1. Install the DevTunnel CLI by following the [official instructions](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Make sure it's in your PATH
+3. Test that it works by running `devtunnel --version`
+
+### Not Logged In
+
+If you're not logged in to DevTunnel:
+
+```bash
+devtunnel login
+```
+
+### Tunnels Not Starting
+
+If tunnels aren't starting, check:
+
+1. That the ports you specified are correct
+2. That your local MCP servers are running on those ports
+3. That the ports aren't being blocked by a firewall

--- a/libraries/python/mcp-tunnel/mcp_tunnel/__init__.py
+++ b/libraries/python/mcp-tunnel/mcp_tunnel/__init__.py
@@ -1,0 +1,3 @@
+from ._main import tunnel_servers
+
+__all__ = ["tunnel_servers"]

--- a/libraries/python/mcp-tunnel/mcp_tunnel/_devtunnel.py
+++ b/libraries/python/mcp-tunnel/mcp_tunnel/_devtunnel.py
@@ -1,0 +1,154 @@
+import json
+import subprocess
+import sys
+
+
+def _exec(args: list[str], timeout: float | None = None) -> tuple[int, str, str]:
+    """
+    Execute a devtunnel command.
+
+    Args:
+        args: List of arguments for the devtunnel command.
+    Returns:
+        A tuple containing:
+        - Return code from the command
+        - Standard output from the command
+        - Standard error from the command
+    """
+    result = subprocess.run(
+        ["devtunnel", *args],
+        capture_output=True,
+        text=True,
+        check=False,  # Don't raise exception if command fails
+        timeout=timeout,
+    )
+
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def is_available() -> tuple[bool, str]:
+    """
+    Check if the devtunnel CLI is available on the system.
+
+    Returns:
+        A tuple containing:
+        - Boolean indicating if devtunnel is available
+        - String with the version information if available, None otherwise
+        - Error message if there was a problem with the devtunnel command
+    """
+    try:
+        code, stdout, stderr = _exec(["--version"], timeout=5)
+
+        if code != 0:
+            return False, f"devtunnel command returned error code {code}: {stderr}"
+
+        return True, ""
+
+    except FileNotFoundError:
+        # Command not found
+        return False, "devtunnel command not found in PATH"
+
+
+def is_logged_in() -> bool:
+    """
+    Check if the user is logged into the devtunnel CLI.
+
+    Returns:
+        Boolean indicating if the user is logged in
+    """
+    code, stdout, _ = _exec(["user", "show", "--json"], timeout=10)
+    if code != 0:
+        return False
+
+    # Check the login status from the output
+    return json.loads(stdout)["status"] == "Logged in"
+
+
+def delete_tunnel(tunnel_id: str) -> bool:
+    """
+    Delete a tunnel by its ID.
+
+    Args:
+        tunnel_id: The ID of the tunnel to delete.
+
+    Returns:
+        Boolean indicating if the deletion was successful.
+    """
+    code, _, stderr = _exec(["delete", tunnel_id, "--force"], timeout=10)
+    if code == 0:
+        return True
+
+    if "not found" in stderr:
+        return True
+
+    print("Error deleting tunnel:", stderr, file=sys.stderr)
+    return False
+
+
+def create_tunnel(tunnel_id: str, port: int) -> bool:
+    """
+    Create a tunnel with the given ID and port.
+
+    Args:
+        tunnel_id: The ID of the tunnel to create.
+        port: The port number for the tunnel.
+
+    Returns:
+        Boolean indicating if the creation was successful.
+    """
+    code, _, stderr = _exec(["create", tunnel_id], timeout=10)
+    if code != 0:
+        print("Error creating tunnel:", stderr, file=sys.stderr)
+        return False
+
+    code, _, stderr = _exec(["port", "create", tunnel_id, "--port-number", str(port), "--protocol", "http"], timeout=10)
+    if code != 0:
+        print("Error creating tunnel:", stderr, file=sys.stderr)
+        delete_tunnel(tunnel_id)
+        return False
+
+    return True
+
+
+def get_access_token(tunnel_id: str) -> str:
+    """
+    Get the access token for a tunnel.
+
+    Args:
+        tunnel_id: The ID of the tunnel.
+
+    Returns:
+        The access token for the tunnel.
+    """
+
+    code, stdout, stderr = _exec(["token", tunnel_id, "--scope", "connect", "--json"], timeout=10)
+    if code != 0:
+        raise RuntimeError(f"Error getting access token: {stderr}")
+
+    return json.loads(stdout)["token"]
+
+
+def get_tunnel_uri(tunnel_id: str) -> str:
+    """
+    Get the URI for a tunnel.
+
+    Args:
+        tunnel_id: The ID of the tunnel.
+
+    Returns:
+        The URI for the tunnel.
+    """
+    code, stdout, stderr = _exec(["show", tunnel_id, "--json"], timeout=10)
+    if code != 0:
+        raise RuntimeError(f"Error getting tunnel URI: {stderr}")
+
+    tunnel = json.loads(stdout).get("tunnel")
+    if not tunnel:
+        raise RuntimeError(f"Tunnel {tunnel_id} not found")
+
+    ports = tunnel.get("ports", [])
+    if not ports:
+        return ""
+
+    port = ports[0]
+    return port.get("portUri") or ""

--- a/libraries/python/mcp-tunnel/mcp_tunnel/_main.py
+++ b/libraries/python/mcp-tunnel/mcp_tunnel/_main.py
@@ -1,0 +1,322 @@
+import argparse
+import pathlib
+import signal
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import IO, NoReturn, cast
+
+import yaml
+from termcolor import cprint
+from termcolor._types import Color
+
+from . import _devtunnel as devtunnel
+
+
+@dataclass
+class MCPServer:
+    name: str
+    port: int
+
+
+@dataclass
+class MCPTunnel:
+    name: str
+    sse_url: str
+    headers: dict[str, str]
+
+
+class TunnelManager:
+    def __init__(self, servers: list[MCPServer]):
+        self.servers = servers
+        self.processes: dict[str, subprocess.Popen] = {}
+        self.should_terminate = threading.Event()
+        self.server_colors = {
+            servers[i].name: [
+                "cyan",
+                "magenta",
+                "green",
+                "yellow",
+                "blue",
+                "white",
+                "light_grey",
+            ][i % 7]
+            for i in range(len(servers))
+        }
+        suffix = uuid.uuid4().hex[:6]
+        self.server_labels = [f"{server.name}-{suffix}" for server in servers]
+
+    def output_reader(self, server_name: str, stream: IO, color: Color):
+        """Thread function to read output from a process stream and print it."""
+
+        prefix = f"[{server_name}] "
+
+        while not self.should_terminate.is_set():
+            line = stream.readline()
+            if not line:
+                break
+
+            line_text = line.rstrip()
+            cprint(f"{prefix}{line_text}", color)
+
+        # Make sure we read any remaining output after termination signal
+        remaining_lines = list(stream)
+        for line in remaining_lines:
+            line_text = line.rstrip()
+            cprint(f"{prefix}{line_text}", color)
+
+    def start_tunnel(self, server: MCPServer) -> MCPTunnel:
+        """Start a single tunnel process for a server."""
+        color = cast(Color, self.server_colors[server.name])
+
+        cprint(f"Starting tunnel for {server.name} on port {server.port}...", color)
+
+        if not devtunnel.delete_tunnel(server.name):
+            cprint(f"Warning: Failed to delete existing tunnel for {server.name}", color, file=sys.stderr)
+            sys.exit(1)
+
+        if not devtunnel.create_tunnel(server.name, server.port):
+            cprint(f"Failed to create new tunnel for {server.name}", color, file=sys.stderr)
+            sys.exit(1)
+
+        access_token = devtunnel.get_access_token(server.name)
+
+        # Start the devtunnel process
+        process = subprocess.Popen(
+            ["devtunnel", "host", server.name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # Line buffered
+        )
+
+        self.processes[server.name] = process
+
+        # Start threads to read stdout and stderr
+        stdout_thread = threading.Thread(
+            target=self.output_reader, args=(server.name, process.stdout, color), daemon=True
+        )
+        stderr_thread = threading.Thread(
+            target=self.output_reader, args=(server.name, process.stderr, "red"), daemon=True
+        )
+
+        stdout_thread.start()
+        stderr_thread.start()
+
+        attempts = 1
+        while attempts <= 10:
+            time.sleep(1)
+            uri = devtunnel.get_tunnel_uri(server.name)
+
+            if not uri:
+                attempts += 1
+                continue
+
+            cprint(f"Tunnel for {server.name} started successfully: {uri}", color)
+
+            uri = uri.rstrip("/") + "/sse"
+            return MCPTunnel(
+                name=server.name, sse_url=uri, headers={"X-Tunnel-Authorization": f"tunnel {access_token}"}
+            )
+
+        self.terminate_tunnels()
+        cprint(f"Failed to start tunnel for {server.name} after 10 attempts", color, file=sys.stderr)
+        sys.exit(1)
+
+    def start_all_tunnels(self) -> None:
+        """Start all tunnel processes."""
+
+        tunnels: list[MCPTunnel] = []
+        for server in self.servers:
+            tunnel = self.start_tunnel(server)
+            tunnels.append(tunnel)
+
+        self.write_assistant_config(tunnels)
+
+    def write_assistant_config(self, tunnels: list[MCPTunnel]) -> None:
+        """
+        extensions_config:
+        tools:
+            enabled: true
+            mcp_servers:
+            - enabled: true
+                key: vscode
+                command: https://88c223vw-6010.usw2.devtunnels.ms/sse
+                args: []
+                env: []
+                prompt: ''
+                long_running: false
+                task_completion_estimate: 30
+            - enabled: false
+                key: fetch
+                command: https://jtsxbnjx-50001.usw2.devtunnels.ms/sse
+                args: []
+                env: []
+                prompt: ''
+                long_running: false
+                task_completion_estimate: 30
+        """
+
+        config = {
+            "extensions_config": {
+                "tools": {
+                    "enabled": True,
+                    "mcp_servers": [
+                        {
+                            "enabled": True,
+                            "key": server.name,
+                            "command": tunnel.sse_url,
+                            "args": [],
+                            "env": [{"key": key, "value": value} for key, value in tunnel.headers.items()],
+                            "prompt": "",
+                            "long_running": False,
+                            "task_completion_estimate": 30,
+                        }
+                        for server, tunnel in zip(self.servers, tunnels)
+                    ],
+                }
+            }
+        }
+
+        mcp_tunnel_dir = pathlib.Path.home() / ".mcp-tunnel"
+        mcp_tunnel_dir.mkdir(exist_ok=True)
+
+        config_path = mcp_tunnel_dir / "config.yaml"
+        config_path.write_text(yaml.dump(config, sort_keys=False))
+
+        print(f"\nConfig file written to: {config_path}")
+
+    def terminate_tunnels(self) -> None:
+        """Terminate all running tunnel processes."""
+        if not self.processes:
+            return
+
+        print("\nShutting down all tunnels...")
+        self.should_terminate.set()
+
+        # First send SIGTERM to all processes
+        for name, process in self.processes.items():
+            print(f"Terminating {name} tunnel...")
+            process.terminate()
+
+        # Wait for processes to terminate gracefully
+        for _ in range(5):  # Wait up to 5 seconds
+            if all(process.poll() is not None for process in self.processes.values()):
+                break
+            time.sleep(1)
+
+        # Force kill any remaining processes
+        for name, process in list(self.processes.items()):
+            if process.poll() is None:
+                print(f"Force killing {name} tunnel...")
+                process.kill()
+                process.wait()
+
+        self.processes.clear()
+        print("All tunnels shut down.")
+
+    def signal_handler(self, sig, frame) -> NoReturn:
+        """Handle Ctrl+C and other termination signals."""
+        print("\nReceived termination signal. Shutting down...")
+        self.terminate_tunnels()
+        sys.exit(0)
+
+
+def parse_arguments():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Run multiple devtunnel processes in parallel")
+    parser.add_argument(
+        "--servers",
+        type=str,
+        default="vscode:6010,office:25566",
+        help="Comma-separated list of server_name:port pairs (default: vscode:6010,office:25566)",
+    )
+    return parser.parse_args()
+
+
+def parse_servers(servers_str):
+    """Parse the servers string into a list of MCPServer objects."""
+    servers = []
+    for server_str in servers_str.split(","):
+        if ":" not in server_str:
+            print(f"Warning: Invalid server format: {server_str}. Expected format: name:port")
+            continue
+
+        name, port_str = server_str.split(":", 1)
+        try:
+            port = int(port_str)
+            servers.append(MCPServer(name, port))
+        except ValueError:
+            print(f"Warning: Invalid port number: {port_str} for server {name}")
+
+    return servers
+
+
+def main():
+    args = parse_arguments()
+    servers = parse_servers(args.servers)
+
+    if not servers:
+        print("Error: No valid servers specified.")
+        return 1
+
+    tunnel_servers(servers)
+
+
+def tunnel_servers(servers: list[MCPServer]):
+    tunnel_manager = TunnelManager(servers)
+
+    # Ensure the `devtunnel` CLI is available
+    if not ensure_devtunnel():
+        return 1
+
+    print("DevTunnel CLI detected and user is logged in")
+    print(f"Starting tunnels for servers: {', '.join(s.name for s in servers)}")
+
+    # Set up signal handlers for graceful shutdown
+    signal.signal(signal.SIGINT, tunnel_manager.signal_handler)
+    signal.signal(signal.SIGTERM, tunnel_manager.signal_handler)
+
+    try:
+        # Start all tunnel processes
+        tunnel_manager.start_all_tunnels()
+
+        # Keep the main thread alive
+        print("\nAll tunnels started. Press Ctrl+C to stop all tunnels.\n")
+        while True:
+            time.sleep(1)
+
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        tunnel_manager.terminate_tunnels()
+        return 1
+
+
+def ensure_devtunnel() -> bool:
+    # Ensure the `devtunnel` CLI is available
+    devtunnel_available, error_msg = devtunnel.is_available()
+    if not devtunnel_available:
+        print("Error: The 'devtunnel' CLI is not available or not working properly.", file=sys.stderr)
+        if error_msg:
+            print(f"Details: {error_msg}", file=sys.stderr)
+        print("Please install the DevTunnel CLI to use this tool.", file=sys.stderr)
+        print(
+            "For installation instructions, visit: https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started",
+            file=sys.stderr,
+        )
+        return False
+
+    # Ensure the user is logged in to the `devtunnel` CLI
+    if not devtunnel.is_logged_in():
+        print("Error: You are not logged in to the DevTunnel CLI.", file=sys.stderr)
+        print("Please log in using 'devtunnel login' command.", file=sys.stderr)
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libraries/python/mcp-tunnel/pyproject.toml
+++ b/libraries/python/mcp-tunnel/pyproject.toml
@@ -22,4 +22,4 @@ mcp-tunnel = "mcp_tunnel._main:main"
 
 
 [dependency-groups]
-dev = ["pyright>=1.1.389", "pytest>=8.3.1"]
+dev = ["pyright>=1.1.389"]

--- a/libraries/python/mcp-tunnel/pyproject.toml
+++ b/libraries/python/mcp-tunnel/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mcp-tunnel"
+version = "0.1.0"
+description = "Command line tool for opening tunnels to local MCP servers."
+authors = [{ name = "Semantic Workbench Team" }]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pyyaml>=6.0.2",
+    "termcolor>=2.5.0",
+]
+
+[project.optional-dependencies]
+
+
+[project.scripts]
+mcp-tunnel = "mcp_tunnel._main:main"
+
+
+[dependency-groups]
+dev = ["pyright>=1.1.389", "pytest>=8.3.1"]

--- a/libraries/python/mcp-tunnel/uv.lock
+++ b/libraries/python/mcp-tunnel/uv.lock
@@ -1,0 +1,155 @@
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "mcp-tunnel"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "termcolor" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "termcolor", specifier = ">=2.5.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.389" },
+    { name = "pytest", specifier = ">=8.3.1" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.394"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612 },
+    { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829 },
+    { url = "https://files.pythonhosted.org/packages/51/16/6af8d6a6b210c8e54f1406a6b9481febf9c64a3109c541567e35a49aa2e7/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317", size = 764167 },
+    { url = "https://files.pythonhosted.org/packages/75/e4/2c27590dfc9992f73aabbeb9241ae20220bd9452df27483b6e56d3975cc5/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85", size = 762952 },
+    { url = "https://files.pythonhosted.org/packages/9b/97/ecc1abf4a823f5ac61941a9c00fe501b02ac3ab0e373c3857f7d4b83e2b6/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4", size = 735301 },
+    { url = "https://files.pythonhosted.org/packages/45/73/0f49dacd6e82c9430e46f4a027baa4ca205e8b0a9dce1397f44edc23559d/PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e", size = 756638 },
+    { url = "https://files.pythonhosted.org/packages/22/5f/956f0f9fc65223a58fbc14459bf34b4cc48dec52e00535c79b8db361aabd/PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5", size = 143850 },
+    { url = "https://files.pythonhosted.org/packages/ed/23/8da0bbe2ab9dcdd11f4f4557ccaf95c10b9811b13ecced089d43ce59c3c8/PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44", size = 161980 },
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "termcolor"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/72/88311445fd44c455c7d553e61f95412cf89054308a1aa2434ab835075fc5/termcolor-2.5.0.tar.gz", hash = "sha256:998d8d27da6d48442e8e1f016119076b690d962507531df4890fcd2db2ef8a6f", size = 13057 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/be/df630c387a0a054815d60be6a97eb4e8f17385d5d6fe660e1c02750062b4/termcolor-2.5.0-py3-none-any.whl", hash = "sha256:37b17b5fc1e604945c2642c872a3764b5d547a48009871aea3edd3afa180afb8", size = 7755 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]

--- a/libraries/python/mcp-tunnel/uv.lock
+++ b/libraries/python/mcp-tunnel/uv.lock
@@ -2,24 +2,6 @@ version = 1
 requires-python = ">=3.11"
 
 [[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
-]
-
-[[package]]
-name = "iniconfig"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
-]
-
-[[package]]
 name = "mcp-tunnel"
 version = "0.1.0"
 source = { editable = "." }
@@ -31,7 +13,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pyright" },
-    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -41,10 +22,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "pyright", specifier = ">=1.1.389" },
-    { name = "pytest", specifier = ">=8.3.1" },
-]
+dev = [{ name = "pyright", specifier = ">=1.1.389" }]
 
 [[package]]
 name = "nodeenv"
@@ -53,24 +31,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
-]
-
-[[package]]
-name = "packaging"
-version = "24.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
 ]
 
 [[package]]
@@ -84,21 +44,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
-]
-
-[[package]]
-name = "pytest"
-version = "8.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
 ]
 
 [[package]]


### PR DESCRIPTION
Supports arbitrary SSE MCP servers, with defaults that match our vscode and office ports.
- Sets up tunnel with `devtunnel`
- Gets URI and access token for tunnel
- Generates assistant config file to be imported