### PR TITLE
fixes for o3-mini when using tools

### DIFF
--- a/assistants/codespace-assistant/assistant/response/response.py
+++ b/assistants/codespace-assistant/assistant/response/response.py
@@ -82,7 +82,11 @@ async def respond_to_conversation(
             sampling_handler=sampling_handler.handle_message,
         )
 
-        if len(config.extensions_config.tools.mcp_servers) > 0 and len(mcp_sessions) == 0:
+        if (
+            config.extensions_config.tools.enabled
+            and len(config.extensions_config.tools.mcp_servers) > 0
+            and len(mcp_sessions) == 0
+        ):
             # No MCP servers are available, so we should not continue
             logger.error("No MCP servers are available.")
             return

--- a/assistants/codespace-assistant/assistant/response/utils/openai_utils.py
+++ b/assistants/codespace-assistant/assistant/response/utils/openai_utils.py
@@ -83,13 +83,16 @@ async def get_completion(
 
     # list of models that do not support tools
     no_tools_support = ["o1-preview", "o1-mini"]
+    no_parallel_tool_calls = ["o3-mini"]
 
     # add tools to completion args if model supports tools
     if request_config.model not in no_tools_support:
         completion_args["tools"] = tools or NotGiven()
         if tools is not None:
             completion_args["tool_choice"] = "auto"
-            completion_args["parallel_tool_calls"] = False
+
+            if request_config.model not in no_parallel_tool_calls:
+                completion_args["parallel_tool_calls"] = False
 
     logger.debug(
         dedent(f"""


### PR DESCRIPTION
Don't send param for `parallel_tool_calls` for o3-mini, it does not support it.

Ensure the `enabled` param for the tools config is respected, even if tools are defined.