### PR TITLE
Enables config for hosted and personal MCP servers

### DIFF
--- a/libraries/python/assistant-extensions/assistant_extensions/mcp/__init__.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/mcp/__init__.py
@@ -15,7 +15,9 @@ from ._openai_utils import (
 from ._server_utils import (
     establish_mcp_sessions,
     get_mcp_server_prompts,
+    get_enabled_mcp_server_configs,
     refresh_mcp_sessions,
+    MCPServerConnectionError,
 )
 from ._tool_utils import handle_mcp_tool_call, retrieve_mcp_tools_from_sessions
 
@@ -27,10 +29,12 @@ __all__ = [
     "MCPSamplingMessageHandler",
     "MCPServerConfig",
     "MCPSession",
+    "MCPServerConnectionError",
     "MCPToolsConfigModel",
     "OpenAISamplingHandler",
     "establish_mcp_sessions",
     "get_mcp_server_prompts",
+    "get_enabled_mcp_server_configs",
     "handle_mcp_tool_call",
     "refresh_mcp_sessions",
     "retrieve_mcp_tools_from_sessions",

--- a/libraries/python/mcp-tunnel/mcp_tunnel/_devtunnel.py
+++ b/libraries/python/mcp-tunnel/mcp_tunnel/_devtunnel.py
@@ -69,7 +69,9 @@ def is_logged_in() -> bool:
     # the output sometimes includes a welcome message :/
     # so we need to truncate anything prior to the first curly brace
     stdout = stdout[stdout.index("{") :]
-    return json.loads(stdout)["status"] == "Logged in"
+    user_response: dict[str, Any] = json.loads(stdout)
+    status = (user_response.get("status") or "").lower()
+    return  status == "logged in"
 
 
 def delete_tunnel(tunnel_id: str) -> bool:

--- a/libraries/python/mcp-tunnel/mcp_tunnel/_main.py
+++ b/libraries/python/mcp-tunnel/mcp_tunnel/_main.py
@@ -214,10 +214,10 @@ def write_assistant_config(servers: list[MCPServer], tunnel: MCPTunnel) -> None:
     extensions_config:
     tools:
         enabled: true
-        mcp_servers:
+        personal_mcp_servers:
         - enabled: true
             key: vscode
-            command: https://88c223vw-6010.usw2.devtunnels.ms/sse
+            command: https://aaaaa-6010.usw2.devtunnels.ms/sse
             args: []
             env: []
             prompt: ''
@@ -225,7 +225,7 @@ def write_assistant_config(servers: list[MCPServer], tunnel: MCPTunnel) -> None:
             task_completion_estimate: 30
         - enabled: false
             key: fetch
-            command: https://jtsxbnjx-50001.usw2.devtunnels.ms/sse
+            command: https://aaaaa-50001.usw2.devtunnels.ms/sse
             args: []
             env: []
             prompt: ''
@@ -237,7 +237,7 @@ def write_assistant_config(servers: list[MCPServer], tunnel: MCPTunnel) -> None:
         "extensions_config": {
             "tools": {
                 "enabled": True,
-                "mcp_servers": [
+                "personal_mcp_servers": [
                     {
                         "key": server.name,
                         "enabled": True,


### PR DESCRIPTION
So we can configure "personal" servers without stomping on the hosted ones.

Hosted MCP server URLs are provided by env vars.

Also includes:
- a change to `mcp-tunnel` that sets the personal_mcp_servers key
- simplifications to the MCP server connection error handling in the codespace-assistant