### PR TITLE
Avoid import-time platform/env specific checks

### DIFF
--- a/mcp-servers/mcp-server-bing-search/mcp_server_bing_search/config.py
+++ b/mcp-servers/mcp-server-bing-search/mcp_server_bing_search/config.py
@@ -2,7 +2,9 @@
 
 import os
 from pathlib import Path
+from typing import Annotated
 
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 log_level = os.environ.get("LOG_LEVEL", "INFO")
@@ -15,25 +17,11 @@ MKITDOWN_TEMP.mkdir(parents=True, exist_ok=True)
 URL_CACHE_FILE = TEMP_DIR / "cache" / "url_cache.json"
 
 
-def load_required_env_var(env_var_name: str) -> str:
-    value = os.environ.get(env_var_name, "")
-    if not value:
-        raise ValueError(f"Missing required environment variable: {env_var_name}")
-    return value
-
-
-# Load required environment variables
-bing_search_api_key = load_required_env_var("BING_SEARCH_API_KEY")
-
-# Load optional environment variables
-azure_endpoint = os.environ.get("ASSISTANT__AZURE_OPENAI_ENDPOINT", None)
-
-
 class Settings(BaseSettings):
     log_level: str = log_level
     dev: bool = True
-    bing_search_api_key: str = bing_search_api_key
-    azure_endpoint: str | None = azure_endpoint
+    bing_search_api_key: Annotated[str, Field(validation_alias="BING_SEARCH_API_KEY")] = ""
+    azure_endpoint: Annotated[str | None, Field(validation_alias="ASSISTANT__AZURE_OPENAI_ENDPOINT")] = None
     concurrency_limit: int = 1
     mkitdown_temp: Path = MKITDOWN_TEMP
     url_cache_file: Path = URL_CACHE_FILE

--- a/mcp-servers/mcp-server-bing-search/mcp_server_bing_search/web/search_bing.py
+++ b/mcp-servers/mcp-server-bing-search/mcp_server_bing_search/web/search_bing.py
@@ -13,6 +13,9 @@ def search_bing(query: str) -> list[SearchResult]:
     """
     # Add your Bing Search V7 subscription key and endpoint to your environment variables.
     subscription_key = settings.bing_search_api_key
+    if not subscription_key:
+        raise ValueError("BING_SEARCH_API_KEY is not set in the environment variables.")
+
     endpoint = "https://api.bing.microsoft.com/v7.0/search"
 
     mkt = "en-US"

--- a/mcp-servers/mcp-server-office/mcp_server/app_interaction/excel_editor.py
+++ b/mcp-servers/mcp-server-office/mcp_server/app_interaction/excel_editor.py
@@ -1,11 +1,15 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import pythoncom
-import win32com.client as win32
+import sys
 
 
 def get_excel_app():
     """Connect to Excel if it is running, or start a new instance."""
+
+    if sys.platform != "win32":
+        raise EnvironmentError("This script only works on Windows.")
+    import win32com.client as win32
+
     try:
         # Try connecting to an existing instance of Excel
         excel = win32.GetActiveObject("Excel.Application")
@@ -77,6 +81,11 @@ def get_workbook_content(workbook):
 
 
 def main():
+    if sys.platform != "win32":
+        raise EnvironmentError("This script only works on Windows.")
+
+    import pythoncom
+
     # Initialize COM
     pythoncom.CoInitialize()
 

--- a/mcp-servers/mcp-server-office/mcp_server/app_interaction/powerpoint_editor.py
+++ b/mcp-servers/mcp-server-office/mcp_server/app_interaction/powerpoint_editor.py
@@ -1,11 +1,15 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import pythoncom
-import win32com.client as win32
+import sys
 
 
 def get_powerpoint_app():
     """Connect to PowerPoint if it is running, or start a new instance."""
+    if sys.platform != "win32":
+        raise EnvironmentError("This script only works on Windows.")
+
+    import win32com.client as win32
+
     try:
         # Try connecting to an existing instance of PowerPoint
         powerpoint = win32.GetActiveObject("PowerPoint.Application")
@@ -84,6 +88,11 @@ def remove_slide(presentation, slide_number):
 
 
 def main():
+    if sys.platform != "win32":
+        raise EnvironmentError("This script is only supported on Windows.")
+
+    import pythoncom
+
     # Initialize COM
     pythoncom.CoInitialize()
 

--- a/mcp-servers/mcp-server-office/mcp_server/app_interaction/word_editor.py
+++ b/mcp-servers/mcp-server-office/mcp_server/app_interaction/word_editor.py
@@ -1,10 +1,15 @@
 # Copyright (c) Microsoft. All rights reserved.
 
 
+import sys
+
 from mcp_server.types import WordCommentData
 
 
 def get_word_app():
+    if sys.platform != "win32":
+        raise EnvironmentError("This script only works on Windows.")
+
     import win32com.client as win32
 
     """Connect to Word if it is running, or start a new instance."""
@@ -265,7 +270,6 @@ def write_markdown_to_document(doc, markdown_text: str) -> None:
 
     lines = markdown_text.split("\n")
     i = 0
-    in_code_block = False
     while i < len(lines):
         line = lines[i].strip()
         i += 1
@@ -274,7 +278,6 @@ def write_markdown_to_document(doc, markdown_text: str) -> None:
             continue
 
         if line.startswith("```"):
-            in_code_block = True
             i_start = i
 
             # Find the end of the code block
@@ -291,7 +294,6 @@ def write_markdown_to_document(doc, markdown_text: str) -> None:
             # Skip the closing code fence
             if i < len(lines):
                 i += 1
-            in_code_block = False
 
             # Restore normal style for next paragraph
             selection.Style = word_app.ActiveDocument.Styles("Normal")

--- a/mcp-servers/mcp-server-office/mcp_server/app_interaction/word_editor.py
+++ b/mcp-servers/mcp-server-office/mcp_server/app_interaction/word_editor.py
@@ -1,11 +1,12 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import win32com.client as win32
 
 from mcp_server.types import WordCommentData
 
 
 def get_word_app():
+    import win32com.client as win32
+
     """Connect to Word if it is running, or start a new instance."""
     try:
         # Try connecting to an existing instance of Word

--- a/mcp-servers/mcp-server-office/tests/test_word_editor.py
+++ b/mcp-servers/mcp-server-office/tests/test_word_editor.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import os
 import time
 
 import pytest
@@ -14,8 +15,16 @@ from mcp_server.app_interaction.word_editor import (
 )
 
 
+@pytest.fixture(scope="function")
+def skip_if_not_on_windows() -> None:
+    """Skip tests if not running on Windows."""
+    if os.name == "nt":
+        return
+    pytest.skip("Skipping test: not running on Windows.")
+
+
 @pytest.fixture
-def word_document():
+def word_document(skip_if_not_on_windows):
     """Fixture that provides an active Word document."""
     word_app = get_word_app()
     doc = get_active_document(word_app)

--- a/mcp-servers/mcp-server-office/tests/test_word_editor.py
+++ b/mcp-servers/mcp-server-office/tests/test_word_editor.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-import os
 import time
 
 import pytest
@@ -15,16 +14,8 @@ from mcp_server.app_interaction.word_editor import (
 )
 
 
-@pytest.fixture(scope="function")
-def skip_if_not_on_windows() -> None:
-    """Skip tests if not running on Windows."""
-    if os.name == "nt":
-        return
-    pytest.skip("Skipping test: not running on Windows.")
-
-
 @pytest.fixture
-def word_document(skip_if_not_on_windows):
+def word_document():
     """Fixture that provides an active Word document."""
     word_app = get_word_app()
     doc = get_active_document(word_app)


### PR DESCRIPTION
And execute them at runtime instead, so that pytest collection can occur (instead of failing when trying to read env vars) - and then skip tests if values aren't set or platform is different than required.