### PR TITLE
Updates app to create conversations without titles

### DIFF
--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_model.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_model.py
@@ -426,7 +426,7 @@ class UpdateConversation(BaseModel):
     Update the conversation's title and/or metadata. Leave a field as None to not update it.
     """
 
-    title: str
+    title: str | None = None
     metadata: dict[str, Any] = {}
 
 

--- a/workbench-app/src/components/Conversations/ConversationCreate.tsx
+++ b/workbench-app/src/components/Conversations/ConversationCreate.tsx
@@ -5,8 +5,6 @@ import {
     DialogOpenChangeData,
     DialogOpenChangeEvent,
     DialogTrigger,
-    Field,
-    Input,
     makeStyles,
     tokens,
 } from '@fluentui/react-components';
@@ -36,7 +34,6 @@ export const ConversationCreate: React.FC<ConversationCreateProps> = (props) => 
     const { open, onOpenChange, onCreate, metadata } = props;
     const classes = useClasses();
     const [createConversation] = useCreateConversationMutation();
-    const [title, setTitle] = React.useState('');
     const [submitted, setSubmitted] = React.useState(false);
 
     const handleSave = React.useCallback(async () => {
@@ -46,19 +43,18 @@ export const ConversationCreate: React.FC<ConversationCreateProps> = (props) => 
         setSubmitted(true);
 
         try {
-            const conversation = await createConversation({ title, metadata }).unwrap();
+            const conversation = await createConversation({ metadata }).unwrap();
             onOpenChange?.(false);
             onCreate?.(conversation);
         } finally {
             setSubmitted(false);
         }
-    }, [createConversation, metadata, onCreate, onOpenChange, submitted, title]);
+    }, [createConversation, metadata, onCreate, onOpenChange, submitted]);
 
     React.useEffect(() => {
         if (!open) {
             return;
         }
-        setTitle('');
         setSubmitted(false);
     }, [open]);
 
@@ -84,16 +80,13 @@ export const ConversationCreate: React.FC<ConversationCreateProps> = (props) => 
                         handleSave();
                     }}
                 >
-                    <Field label="Title">
-                        <Input disabled={submitted} value={title} onChange={(_event, data) => setTitle(data.value)} />
-                    </Field>
-                    <button disabled={!title || submitted} type="submit" hidden />
+                    <button disabled={submitted} type="submit" hidden />
                 </form>
             }
             closeLabel="Cancel"
             additionalActions={[
                 <DialogTrigger key="save" disableButtonEnhancement>
-                    <Button disabled={!title || submitted} appearance="primary" onClick={handleSave}>
+                    <Button disabled={submitted} appearance="primary" onClick={handleSave}>
                         {submitted ? 'Saving...' : 'Save'}
                     </Button>
                 </DialogTrigger>,

--- a/workbench-app/src/components/FrontDoor/Controls/NewConversationButton.tsx
+++ b/workbench-app/src/components/FrontDoor/Controls/NewConversationButton.tsx
@@ -12,7 +12,6 @@ export const NewConversationButton: React.FC = () => {
     const [open, setOpen] = React.useState(false);
     const { createConversation } = useCreateConversation();
     const [isValid, setIsValid] = React.useState(false);
-    const [title, setTitle] = React.useState<string>();
     const [assistantId, setAssistantId] = React.useState<string>();
     const [name, setName] = React.useState<string>();
     const [assistantServiceId, setAssistantServiceId] = React.useState<string>();
@@ -21,7 +20,7 @@ export const NewConversationButton: React.FC = () => {
     const { notifyError } = useNotify();
 
     const handleCreate = React.useCallback(async () => {
-        if (submitted || !isValid || !title || !assistantId) {
+        if (submitted || !isValid || !assistantId) {
             return;
         }
 
@@ -39,7 +38,7 @@ export const NewConversationButton: React.FC = () => {
         setSubmitted(true);
 
         try {
-            const { conversation } = await createConversation(title, assistantInfo);
+            const { conversation } = await createConversation(assistantInfo);
             navigateToConversation(conversation.id);
         } finally {
             // In case of error, allow user to retry
@@ -47,7 +46,7 @@ export const NewConversationButton: React.FC = () => {
         }
 
         setOpen(false);
-    }, [assistantId, assistantServiceId, createConversation, isValid, name, navigateToConversation, submitted, title]);
+    }, [assistantId, assistantServiceId, createConversation, isValid, name, navigateToConversation, submitted]);
 
     const handleImport = React.useCallback(
         (conversationIds: string[]) => {
@@ -80,7 +79,6 @@ export const NewConversationButton: React.FC = () => {
                     onSubmit={handleCreate}
                     onChange={(isValid, data) => {
                         setIsValid(isValid);
-                        setTitle(data.title);
                         setAssistantId(data.assistantId);
                         setAssistantServiceId(data.assistantServiceId);
                         setName(data.name);

--- a/workbench-app/src/components/FrontDoor/Controls/NewConversationForm.tsx
+++ b/workbench-app/src/components/FrontDoor/Controls/NewConversationForm.tsx
@@ -26,7 +26,6 @@ const useClasses = makeStyles({
 });
 
 export interface NewConversationData {
-    title?: string;
     assistantId?: string;
     assistantServiceId?: string;
     name?: string;
@@ -44,7 +43,6 @@ export const NewConversationForm: React.FC<NewConversationFormProps> = (props) =
     const { assistants, assistantServicesByCategories } = useCreateConversation();
 
     const [config, setConfig] = React.useState<NewConversationData>({
-        title: '',
         assistantId: '',
         assistantServiceId: '',
         name: '',
@@ -52,7 +50,7 @@ export const NewConversationForm: React.FC<NewConversationFormProps> = (props) =
     const [manualEntry, setManualEntry] = React.useState(false);
 
     const checkIsValid = React.useCallback((data: NewConversationData) => {
-        if (!data.title || !data.assistantId) {
+        if (!data.assistantId) {
             return false;
         }
 
@@ -91,14 +89,6 @@ export const NewConversationForm: React.FC<NewConversationFormProps> = (props) =
             }}
         >
             <div className={classes.content}>
-                <Field label="Title">
-                    <Input
-                        disabled={disabled}
-                        value={config.title}
-                        onChange={(_event, data) => updateAndNotifyChange({ title: data?.value })}
-                        aria-autocomplete="none"
-                    />
-                </Field>
                 <Field label="Assistant">
                     <AssistantSelector
                         assistants={assistants}

--- a/workbench-app/src/components/FrontDoor/MainContent.tsx
+++ b/workbench-app/src/components/FrontDoor/MainContent.tsx
@@ -58,7 +58,6 @@ export const MainContent: React.FC<MainContentProps> = (props) => {
     const activeConversationId = useAppSelector((state) => state.app.activeConversationId);
     const { createConversation } = useCreateConversation();
     const [isValid, setIsValid] = React.useState(false);
-    const [title, setTitle] = React.useState<string>();
     const [assistantId, setAssistantId] = React.useState<string>();
     const [name, setName] = React.useState<string>();
     const [assistantServiceId, setAssistantServiceId] = React.useState<string>();
@@ -75,7 +74,7 @@ export const MainContent: React.FC<MainContentProps> = (props) => {
     }, [activeConversationId, siteUtility]);
 
     const handleCreate = React.useCallback(async () => {
-        if (submitted || !isValid || !title || !assistantId) {
+        if (submitted || !isValid || !assistantId) {
             return;
         }
 
@@ -93,13 +92,13 @@ export const MainContent: React.FC<MainContentProps> = (props) => {
         setSubmitted(true);
 
         try {
-            const { conversation } = await createConversation(title, assistantInfo);
+            const { conversation } = await createConversation(assistantInfo);
             navigateToConversation(conversation.id);
         } finally {
             // In case of error, allow user to retry
             setSubmitted(false);
         }
-    }, [assistantId, assistantServiceId, createConversation, isValid, name, navigateToConversation, submitted, title]);
+    }, [assistantId, assistantServiceId, createConversation, isValid, name, navigateToConversation, submitted]);
 
     const handleImport = React.useCallback(
         (conversationIds: string[]) => {
@@ -129,7 +128,6 @@ export const MainContent: React.FC<MainContentProps> = (props) => {
                             onSubmit={handleCreate}
                             onChange={(isValid, data) => {
                                 setIsValid(isValid);
-                                setTitle(data.title);
                                 setAssistantId(data.assistantId);
                                 setAssistantServiceId(data.assistantServiceId);
                                 setName(data.name);

--- a/workbench-app/src/libs/useConversationUtility.ts
+++ b/workbench-app/src/libs/useConversationUtility.ts
@@ -141,7 +141,7 @@ export const useConversationUtility = () => {
 
             // Save the conversation
             await updateConversation({
-                ...conversation,
+                id: conversation.id,
                 metadata: {
                     ...conversation.metadata,
                     participantAppMetadata: {

--- a/workbench-app/src/libs/useCreateConversation.ts
+++ b/workbench-app/src/libs/useCreateConversation.ts
@@ -65,7 +65,6 @@ export const useCreateConversation = () => {
 
     const create = React.useCallback(
         async (
-            title: string,
             assistantInfo:
                 | {
                       assistantId: string;
@@ -81,7 +80,7 @@ export const useCreateConversation = () => {
 
             let assistant: Assistant | undefined = undefined;
 
-            const conversation = await createConversation({ title }).unwrap();
+            const conversation = await createConversation({}).unwrap();
 
             if ('assistantId' in assistantInfo) {
                 assistant = assistants?.find((a) => a.id === assistantInfo.assistantId);

--- a/workbench-app/src/services/workbench/conversation.ts
+++ b/workbench-app/src/services/workbench/conversation.ts
@@ -16,7 +16,7 @@ interface GetConversationMessagesProps {
 
 export const conversationApi = workbenchApi.injectEndpoints({
     endpoints: (builder) => ({
-        createConversation: builder.mutation<Conversation, Partial<Conversation> & Pick<Conversation, 'title'>>({
+        createConversation: builder.mutation<Conversation, Partial<Conversation>>({
             query: (body) => ({
                 url: '/conversations',
                 method: 'POST',
@@ -37,7 +37,7 @@ export const conversationApi = workbenchApi.injectEndpoints({
             invalidatesTags: ['Conversation'],
             transformResponse: (response: any) => transformResponseToImportResult(response),
         }),
-        updateConversation: builder.mutation<Conversation, Pick<Conversation, 'id' | 'title' | 'metadata'>>({
+        updateConversation: builder.mutation<Conversation, Partial<Conversation> & Pick<Conversation, 'id'>>({
             query: (body) => ({
                 url: `/conversations/${body.id}`,
                 method: 'PATCH',


### PR DESCRIPTION
And never request one from the user on creation - just select the assistant. The conversation will be automatically re-titled as messages are sent by the user, and the user can always re-title manually.

Additionally updates the conversation re-titling to include all chat messages from user, assistant or otherwise.