### PR TITLE
Add token usage tracking and display

### DIFF
--- a/assistants/codespace-assistant/assistant/response/completion_handler.py
+++ b/assistants/codespace-assistant/assistant/response/completion_handler.py
@@ -114,6 +114,15 @@ async def handle_completion(
             )
         )
 
+        await context.update_conversation(
+            metadata={
+                "token_counts": {
+                    "total": total_tokens,
+                    "max": request_config.max_tokens,
+                }
+            }
+        )
+
     # Track the end time of the response generation and calculate duration
     response_end_time = time.time()
     response_duration = response_end_time - response_start_time

--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_model.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_model.py
@@ -220,6 +220,10 @@ class FileVersions(BaseModel):
     versions: list[FileVersion]
 
 
+class UpdateFile(BaseModel):
+    metadata: dict[str, Any]
+
+
 class ConversationImportResult(BaseModel):
     conversation_ids: list[uuid.UUID]
     assistant_ids: list[uuid.UUID]

--- a/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_service_client.py
+++ b/libraries/python/semantic-workbench-api-model/semantic_workbench_api_model/workbench_service_client.py
@@ -134,6 +134,17 @@ class ConversationAPIClient:
             http_response.raise_for_status()
             return workbench_model.Conversation.model_validate(http_response.json())
 
+    async def update_conversation(self, metadata: dict[str, Any]) -> workbench_model.Conversation:
+        async with self._client as client:
+            http_response = await client.patch(
+                f"/conversations/{self._conversation_id}",
+                json=workbench_model.UpdateConversation(metadata=metadata).model_dump(
+                    mode="json", exclude_unset=True, exclude_defaults=True
+                ),
+            )
+            http_response.raise_for_status()
+            return workbench_model.Conversation.model_validate(http_response.json())
+
     async def get_participant_me(self) -> workbench_model.ConversationParticipant:
         async with self._client as client:
             http_response = await client.get(f"/conversations/{self._conversation_id}/participants/me")
@@ -226,7 +237,7 @@ class ConversationAPIClient:
             for message in messages:
                 http_response = await client.post(
                     f"/conversations/{self._conversation_id}/messages",
-                    json=message.model_dump(mode="json"),
+                    json=message.model_dump(mode="json", exclude_unset=True, exclude_defaults=True),
                 )
                 http_response.raise_for_status()
                 message_out = workbench_model.ConversationMessage.model_validate(http_response.json())
@@ -243,7 +254,7 @@ class ConversationAPIClient:
             http_response = await client.post(
                 f"/assistants/{assistant_id}/states/events",
                 params={"conversation_id": self._conversation_id},
-                json=state_event.model_dump(mode="json"),
+                json=state_event.model_dump(mode="json", exclude_unset=True, exclude_defaults=True),
             )
             http_response.raise_for_status()
 
@@ -323,6 +334,21 @@ class ConversationAPIClient:
             if http_response.status_code == httpx.codes.NOT_FOUND:
                 return
             http_response.raise_for_status()
+
+    async def update_file(
+        self,
+        filename: str,
+        metadata: dict[str, Any],
+    ) -> workbench_model.FileVersions:
+        async with self._client as client:
+            http_response = await client.patch(
+                f"/conversations/{self._conversation_id}/files/{filename}",
+                json=workbench_model.UpdateFile(metadata=metadata).model_dump(
+                    mode="json", exclude_unset=True, exclude_defaults=True
+                ),
+            )
+            http_response.raise_for_status()
+            return workbench_model.FileVersions.model_validate(http_response.json())
 
 
 class ConversationsAPIClient:

--- a/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/context.py
+++ b/libraries/python/semantic-workbench-assistant/semantic_workbench_assistant/assistant_app/context.py
@@ -82,6 +82,9 @@ class ConversationContext:
     async def get_conversation(self) -> workbench_model.Conversation:
         return await self._workbench_client.get_conversation()
 
+    async def update_conversation(self, metadata: dict[str, Any]) -> workbench_model.Conversation:
+        return await self._workbench_client.update_conversation(metadata)
+
     async def get_participants(self, include_inactive=False) -> workbench_model.ConversationParticipantList:
         return await self._workbench_client.get_participants(include_inactive=include_inactive)
 
@@ -129,6 +132,9 @@ class ConversationContext:
 
     async def delete_file(self, filename: str) -> None:
         return await self._workbench_client.delete_file(filename)
+
+    async def update_file(self, filename: str, metadata: dict[str, Any]) -> workbench_model.FileVersions:
+        return await self._workbench_client.update_file(filename, metadata)
 
     @asynccontextmanager
     async def state_updated_event_after(self, state_id: str, focus_event: bool = False) -> AsyncIterator[None]:

--- a/workbench-app/src/components/Conversations/Canvas/ConversationCanvas.tsx
+++ b/workbench-app/src/components/Conversations/Canvas/ConversationCanvas.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { Conversation } from '../../../models/Conversation';
 import { ConversationFile } from '../../../models/ConversationFile';
 import { ConversationParticipant } from '../../../models/ConversationParticipant';
+import { ContextWindow } from '../ContextWindow';
 import { ConversationTranscript } from '../ConversationTranscript';
 import { FileList } from '../FileList';
 import { ParticipantList } from '../ParticipantList';
@@ -57,6 +58,12 @@ export const ConversationCanvas: React.FC<ConversationCanvasProps> = (props) => 
                     Transcript
                 </Text>
                 <ConversationTranscript conversation={conversation} participants={conversationParticipants} />
+            </Card>
+            <Card className={classes.card}>
+                <Text size={400} weight="semibold">
+                    Context window
+                </Text>
+                <ContextWindow conversation={conversation} />
             </Card>
             <Card className={classes.card}>
                 <Text size={400} weight="semibold">

--- a/workbench-app/src/components/Conversations/ContextWindow.tsx
+++ b/workbench-app/src/components/Conversations/ContextWindow.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+import { ProgressBar } from '@fluentui/react-components';
+import React from 'react';
+import { Conversation } from '../../models/Conversation';
+
+interface FileListProps {
+    conversation: Conversation;
+}
+
+export const ContextWindow: React.FC<FileListProps> = (props) => {
+    const { conversation } = props;
+
+    const tokenCountToDisplay = (count: number | undefined, includeLabel: boolean = true) => {
+        const label = includeLabel ? ' token' + (count !== 1 ? 's' : '') : '';
+        if (!count) {
+            return `0${label}`;
+        }
+        if (count < 1_000) {
+            return `${count}${label}`;
+        } else if (count < 1_000_000) {
+            return `${(count / 1_000).toFixed(1).toString().replaceAll('.0', '')}k${label}`;
+        } else {
+            return `${(count / 1_000_000).toFixed(1).toString().replaceAll('.0', '')}m${label}`;
+        }
+    };
+
+    if (conversation.metadata?.token_counts === undefined) {
+        return 'Token count not available';
+    }
+
+    const { total: totalTokenCount, max: maxTokenCount } = conversation.metadata?.token_counts;
+
+    return (
+        <>
+            {tokenCountToDisplay(totalTokenCount, false)} of {tokenCountToDisplay(maxTokenCount)} (
+            {Math.floor((totalTokenCount / maxTokenCount) * 100)}%)
+            <ProgressBar thickness="large" value={totalTokenCount / maxTokenCount}></ProgressBar>
+        </>
+    );
+};

--- a/workbench-app/src/components/Conversations/FileItem.tsx
+++ b/workbench-app/src/components/Conversations/FileItem.tsx
@@ -55,6 +55,16 @@ export const FileItem: React.FC<FileItemProps> = (props) => {
         }
     };
 
+    const tokenCountToDisplay = (count: number) => {
+        if (count < 1_000) {
+            return `${count} token` + (count !== 1 ? 's' : '');
+        } else if (count < 1_000_000) {
+            return `${(count / 1_000).toFixed(2)} K tokens`;
+        } else {
+            return `${(count / 1_000_000).toFixed(2)} M tokens`;
+        }
+    };
+
     const handleDelete = React.useCallback(async () => {
         if (submitted) {
             return;
@@ -127,7 +137,10 @@ export const FileItem: React.FC<FileItemProps> = (props) => {
                 }
                 description={
                     <Caption1>
-                        {time} | {sizeToDisplay(conversationFile.size)}
+                        {time} | {sizeToDisplay(conversationFile.size)}{' '}
+                        {conversationFile.metadata?.token_count !== undefined
+                            ? `| ${tokenCountToDisplay(conversationFile.metadata?.token_count)}`
+                            : ''}
                     </Caption1>
                 }
                 action={

--- a/workbench-app/src/components/Conversations/FileItem.tsx
+++ b/workbench-app/src/components/Conversations/FileItem.tsx
@@ -49,19 +49,20 @@ export const FileItem: React.FC<FileItemProps> = (props) => {
         if (size < 1024) {
             return `${size} B`;
         } else if (size < 1024 * 1024) {
-            return `${(size / 1024).toFixed(2)} KB`;
+            return `${(size / 1024).toFixed(1).toString().replaceAll('.0', '')} KB`;
         } else {
-            return `${(size / 1024 / 1024).toFixed(2)} MB`;
+            return `${(size / 1024 / 1024).toFixed(1).toString().replaceAll('.0', '')} MB`;
         }
     };
 
     const tokenCountToDisplay = (count: number) => {
+        const label = `token${count !== 1 ? 's' : ''}`;
         if (count < 1_000) {
-            return `${count} token` + (count !== 1 ? 's' : '');
+            return `${count} ${label}`;
         } else if (count < 1_000_000) {
-            return `${(count / 1_000).toFixed(2)} K tokens`;
+            return `${(count / 1_000).toFixed(2).toString().replaceAll('.0', '')}k ${label}`;
         } else {
-            return `${(count / 1_000_000).toFixed(2)} M tokens`;
+            return `${(count / 1_000_000).toFixed(2).toString().replaceAll('.0', '')}m ${label}`;
         }
     };
 

--- a/workbench-app/src/libs/useConversationUtility.ts
+++ b/workbench-app/src/libs/useConversationUtility.ts
@@ -143,7 +143,6 @@ export const useConversationUtility = () => {
             await updateConversation({
                 id: conversation.id,
                 metadata: {
-                    ...conversation.metadata,
                     participantAppMetadata: {
                         ...participantAppMetadata,
                         [localUserId]: { ...userAppMetadata, ...appMetadata },

--- a/workbench-app/src/libs/useHistoryUtility.ts
+++ b/workbench-app/src/libs/useHistoryUtility.ts
@@ -21,6 +21,7 @@ export const useHistoryUtility = (conversationId: string) => {
         data: conversation,
         error: conversationError,
         isLoading: conversationIsLoading,
+        refetch: refetchConversation,
     } = useGetConversationQuery(conversationId, { refetchOnMountOrArgChange: true });
     const {
         data: allConversationMessages,
@@ -191,5 +192,6 @@ export const useHistoryUtility = (conversationId: string) => {
         assistantsRefetch,
         assistantCapabilitiesIsFetching,
         rewindToBefore,
+        refetchConversation,
     };
 };

--- a/workbench-app/src/models/Conversation.ts
+++ b/workbench-app/src/models/Conversation.ts
@@ -10,7 +10,7 @@ export interface Conversation {
     created: string;
     latest_message?: ConversationMessage;
     participants: ConversationParticipant[];
-    metadata?: {
+    metadata: {
         [key: string]: any;
     };
     conversationPermission: 'read' | 'read_write';

--- a/workbench-app/src/models/ConversationFile.ts
+++ b/workbench-app/src/models/ConversationFile.ts
@@ -7,4 +7,7 @@ export interface ConversationFile {
     size: number;
     version: number;
     contentType: string;
+    metadata: {
+        [key: string]: any;
+    };
 }

--- a/workbench-app/src/services/workbench/conversation.ts
+++ b/workbench-app/src/services/workbench/conversation.ts
@@ -27,7 +27,7 @@ export const conversationApi = workbenchApi.injectEndpoints({
         }),
         duplicateConversation: builder.mutation<
             { conversationIds: string[]; assistantIds: string[] },
-            Pick<Conversation, 'id' | 'title' | 'metadata'>
+            Pick<Conversation, 'id' | 'title'>
         >({
             query: (body) => ({
                 url: `/conversations/${body.id}`,

--- a/workbench-app/src/services/workbench/file.ts
+++ b/workbench-app/src/services/workbench/file.ts
@@ -42,6 +42,7 @@ const transformResponseToFile = (response: any): ConversationFile => {
             size: response.file_size,
             version: response.current_version,
             contentType: response.content_type,
+            metadata: response.metadata,
         };
     } catch (error) {
         throw new Error(`Failed to transform file response: ${error}`);

--- a/workbench-service/semantic_workbench_service/controller/conversation.py
+++ b/workbench-service/semantic_workbench_service/controller/conversation.py
@@ -1,11 +1,11 @@
 import datetime
 import logging
-import openai_client
-from openai.types.chat import ChatCompletionMessageParam
 import uuid
 from typing import Annotated, AsyncContextManager, Awaitable, Callable, Iterable, Literal, Sequence
 
 import deepmerge
+import openai_client
+from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel, Field, HttpUrl
 from semantic_workbench_api_model.assistant_service_client import AssistantError
 from semantic_workbench_api_model.workbench_model import (
@@ -291,7 +291,7 @@ class ConversationController:
         self,
         conversation_id: uuid.UUID,
         update_conversation: UpdateConversation,
-        user_principal: auth.UserPrincipal,
+        user_principal: auth.ActorPrincipal,
     ) -> Conversation:
         async with self._get_session() as session:
             conversation = (
@@ -302,7 +302,6 @@ class ConversationController:
                     )
                     .where(
                         db.Conversation.conversation_id == conversation_id,
-                        db.Conversation.owner_id == user_principal.user_id,
                     )
                     .with_for_update()
                 )
@@ -314,7 +313,7 @@ class ConversationController:
                 match key:
                     case "metadata":
                         system_entries = {k: v for k, v in conversation.meta_data.items() if k.startswith("__")}
-                        conversation.meta_data = {**value, **system_entries}
+                        conversation.meta_data = {**conversation.meta_data, **value, **system_entries}
                     case "title":
                         if value == conversation.title:
                             continue

--- a/workbench-service/semantic_workbench_service/service.py
+++ b/workbench-service/semantic_workbench_service/service.py
@@ -74,6 +74,7 @@ from semantic_workbench_api_model.workbench_model import (
     UpdateAssistantServiceRegistration,
     UpdateAssistantServiceRegistrationUrl,
     UpdateConversation,
+    UpdateFile,
     UpdateParticipant,
     UpdateUser,
     User,
@@ -803,7 +804,7 @@ def init(
     async def update_conversation(
         conversation_id: uuid.UUID,
         update_conversation: UpdateConversation,
-        user_principal: auth.DependsUserPrincipal,
+        user_principal: auth.DependsActorPrincipal,
     ) -> Conversation:
         return await conversation_controller.update_conversation(
             user_principal=user_principal,
@@ -1006,6 +1007,20 @@ def init(
             result.stream,
             media_type=result.content_type,
             headers={"Content-Disposition": f'attachment; filename="{result.filename}"'},
+        )
+
+    @app.patch("/conversations/{conversation_id}/files/{filename:path}")
+    async def update_file(
+        conversation_id: uuid.UUID,
+        filename: str,
+        principal: auth.DependsActorPrincipal,
+        update_file: UpdateFile,
+    ) -> FileVersions:
+        return await file_controller.update_file_metadata(
+            conversation_id=conversation_id,
+            filename=filename,
+            principal=principal,
+            metadata=update_file.metadata,
         )
 
     @app.delete("/conversations/{conversation_id}/files/{filename:path}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
- Track and display token usage for conversations with progress bar
- Add token count display for files
- Add backend support for updating file metadata
- Ensure metadata is properly merged rather than replaced
- Add event listener for conversation updates to refresh data
- Refactor message creation for attachments