### PR TITLE
Adds filesystem-edit tool guidance

### DIFF
--- a/assistants/codespace-assistant/assistant/config.py
+++ b/assistants/codespace-assistant/assistant/config.py
@@ -175,6 +175,7 @@ class HostedMCPServersConfigModel(BaseModel):
         "MCP_SERVER_FILESYSTEM_EDIT_URL",
         # configures the filesystem edit server to use the client-side storage (using the magic hostname of "workspace")
         roots=[MCPClientRoot(name="root", uri="file://workspace/")],
+        prompts_to_auto_include=["instructions"],
         enabled=False,
     )
 


### PR DESCRIPTION
- adds the instructions as a prompt served by the mcp-server-filesystem-edit
- configures codespace-assistant to auto-include this prompt