### PR TITLE
Enables document locking

### DIFF
--- a/assistants/codespace-assistant/assistant/chat.py
+++ b/assistants/codespace-assistant/assistant/chat.py
@@ -142,7 +142,10 @@ async def on_message_created(
         return
 
     # update the participant status to indicate the assistant is thinking
-    async with context.set_status("thinking..."):
+    async with (
+        context.set_status("thinking..."),
+        document_inspector.sideband_event_for_document_lock(assistant, context),
+    ):
         config = await assistant_config.get(context.assistant)
         metadata: dict[str, Any] = {"debug": {"content_safety": event.data.get(content_safety.metadata_key, {})}}
 

--- a/assistants/codespace-assistant/assistant/document_inspector.py
+++ b/assistants/codespace-assistant/assistant/document_inspector.py
@@ -1,7 +1,10 @@
+import datetime
 import io
 import logging
+import uuid
+from contextlib import asynccontextmanager
 from hashlib import md5
-from typing import Annotated, Any, Protocol
+from typing import Annotated, Any, AsyncGenerator, Protocol
 
 from pydantic import BaseModel, ValidationError
 from semantic_workbench_api_model import workbench_model
@@ -23,18 +26,20 @@ class DocumentFileStateModel(BaseModel):
     content: Annotated[str, UISchema(widget="textarea", rows=800, hide_label=True)]
 
 
-def _get_ui_schema() -> dict[str, Any]:
+def _get_ui_schema(readonly: bool) -> dict[str, Any]:
     schema = get_ui_schema(DocumentFileStateModel)
     schema["ui:options"] = {
         **schema.get("ui:options", {}),
         "collapsible": False,
         "title": "Document Editor",
+        "readonly": readonly,
     }
     return schema
 
 
 class InspectorController(Protocol):
     async def is_enabled(self, context: ConversationContext) -> bool: ...
+    async def is_read_only(self, context: ConversationContext) -> bool: ...
 
     async def get_current_document(self, context: ConversationContext) -> DocumentFileStateModel | None: ...
 
@@ -78,7 +83,7 @@ class EditableDocumentFileStateInspector:
         return AssistantConversationInspectorStateDataModel(
             data=document.model_dump(mode="json"),
             json_schema=document.model_json_schema(),
-            ui_schema=_get_ui_schema(),
+            ui_schema=_get_ui_schema(await self._controller.is_read_only(context)),
         )
 
     async def set(
@@ -86,7 +91,7 @@ class EditableDocumentFileStateInspector:
         context: ConversationContext,
         data: dict[str, Any],
     ) -> None:
-        if not self._controller.is_enabled(context):
+        if not self._controller.is_enabled(context) or self._controller.is_read_only(context):
             return
 
         document = await self._controller.get_current_document(context)
@@ -155,6 +160,7 @@ class DocumentInspectors:
         config: BaseModelAssistantConfig[AssistantConfigModel],
     ) -> None:
         self._selected_file: dict[str, str] = {}
+        self._readonly: set[str] = set()
         self._config = config
 
         viewer = ReadonlyDocumentFileStateInspector(
@@ -168,6 +174,16 @@ class DocumentInspectors:
             display_name="Document Editor",
         )
         app.add_inspector_state_provider(state_id=editor.state_id, provider=editor)
+
+        async def emit_state_change_event(ctx: ConversationContext) -> None:
+            for state_id in (editor.state_id, viewer.state_id):
+                await ctx.send_conversation_state_event(
+                    workbench_model.AssistantStateEvent(
+                        state_id=state_id,
+                        event="updated",
+                        state=None,
+                    )
+                )
 
         @app.events.conversation.file.on_created_including_mine
         @app.events.conversation.file.on_updated_including_mine
@@ -184,14 +200,30 @@ class DocumentInspectors:
             if event.event == workbench_model.ConversationEventType.file_deleted:
                 self._selected_file.pop(ctx.id, None)
 
-            for state_id in (editor.state_id, viewer.state_id):
-                await ctx.send_conversation_state_event(
-                    workbench_model.AssistantStateEvent(
-                        state_id=state_id,
-                        event="updated",
-                        state=None,
-                    )
-                )
+            await emit_state_change_event(ctx)
+
+        @app.events.conversation.participant.on_updated_including_mine
+        async def on_participant_update(
+            ctx: ConversationContext,
+            event: workbench_model.ConversationEvent,
+            participant: workbench_model.ConversationParticipant,
+        ) -> None:
+            documents_locked = participant.metadata.get("document_lock", None)
+            if documents_locked is None:
+                return
+
+            match documents_locked:
+                case True:
+                    if ctx.id in self._readonly:
+                        return
+                    self._readonly.add(ctx.id)
+                    await emit_state_change_event(ctx)
+
+                case False:
+                    if ctx.id not in self._readonly:
+                        return
+                    self._readonly.remove(ctx.id)
+                    await emit_state_change_event(ctx)
 
     async def is_enabled(self, context: ConversationContext) -> bool:
         config = await self._config.get(context.assistant)
@@ -201,6 +233,9 @@ class DocumentInspectors:
             for server in config.tools.personal_mcp_servers
             if server.key == config.tools.hosted_mcp_servers.filesystem_edit.key and server.enabled
         ])
+
+    async def is_read_only(self, context: ConversationContext) -> bool:
+        return context.id in self._readonly
 
     async def get_current_document(self, context: ConversationContext) -> DocumentFileStateModel | None:
         files_response = await context.list_files()
@@ -225,3 +260,53 @@ class DocumentInspectors:
         file_content = buffer.getvalue().decode("utf-8")
 
         return DocumentFileStateModel(content=file_content, filename=selected_file.filename)
+
+
+@asynccontextmanager
+async def sideband_event_for_document_lock(
+    app: AssistantAppProtocol, context: ConversationContext
+) -> AsyncGenerator[None, None]:
+    """
+    A temporary work-around to call the event handlers directly to communicate the document lock
+    status to the document inspectors. This circumvents the serialization of event delivery by
+    calling the event handlers directly.
+
+    It uses an arbitrary event type that the inspector is listening for. The key data is in the
+    Participant.metadata["document_lock"] field. The rest is unused.
+    """
+
+    def participant(lock: bool) -> workbench_model.ConversationParticipant:
+        return workbench_model.ConversationParticipant(
+            conversation_id=uuid.UUID(context.id),
+            active_participant=True,
+            conversation_permission=workbench_model.ConversationPermission.read,
+            id="",
+            role=workbench_model.ParticipantRole.assistant,
+            name="",
+            status=None,
+            metadata={
+                "document_lock": lock,
+            },
+            status_updated_timestamp=datetime.datetime.now(),
+            image=None,
+        )
+
+    # lock document edits
+    await app.events.conversation.participant._on_updated_handlers(
+        False,
+        context,
+        None,
+        participant(True),
+    )
+
+    try:
+        yield
+
+    finally:
+        # unlock the documents
+        await app.events.conversation.participant._on_updated_handlers(
+            False,
+            context,
+            None,
+            participant(False),
+        )


### PR DESCRIPTION
To prevent user edits with the document inspector when the codespace-assistant is responding to a message.