### PR TITLE
Update readme and fix the echo bot logging dependency

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -33,6 +33,11 @@ For more details on using GitHub Codespaces in VS Code, see the [documentation](
 
 ## How to use
 
+IMPORTANT: Make sure to open the main workspace file: `semantic-workbench.code-workspace` and not just open the root folder in VSCode: 
+
+`File` -> `Open Workspace from File...` -> Choose the `semantic-workbench.code-workspace` file from the list.
+
+
 ### Connecting to the Codespace in the future
 
 - Launch VS Code and open the command palette with the `F1` key or `Ctrl/Cmd+Shift+P`

--- a/examples/python/python-01-echo-bot/uv.lock
+++ b/examples/python/python-01-echo-bot/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -480,11 +481,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "2.0.7"
+version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/da/95963cebfc578dabd323d7263958dfb68898617912bb09327dd30e9c8d13/python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c", size = 10508 }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a6/145655273568ee78a581e734cf35beb9e33a370b29c5d3c8fee3744de29f/python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd", size = 8067 },
+    { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes:
- Update the readme to add instructions on how to properly open the workspace when using codespaces
- Fix / upgrade the `python-json-logger` dependency in the echo bot example