### PR TITLE
Allows font-synthesis

### DIFF
--- a/workbench-app/src/index.css
+++ b/workbench-app/src/index.css
@@ -1,5 +1,4 @@
 :root {
-    font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
So italics will render on platforms that don't have Segoe UI font installed locally (such as Mac)