### PR TITLE
Fix ruff config in assistant-extensions

### DIFF
--- a/libraries/python/assistant-extensions/assistant_extensions/document_editor/_extension.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/document_editor/_extension.py
@@ -40,9 +40,7 @@ class DocumentEditorExtension:
         drive = Drive(DriveConfig(root=root))
         return drive
 
-    def client_resource_handler_for(
-        self, ctx: ConversationContext
-    ) -> AssistantFileResourceHandler:
+    def client_resource_handler_for(self, ctx: ConversationContext) -> AssistantFileResourceHandler:
         return AssistantFileResourceHandler(
             context=ctx,
             drive=self._drive_for(ctx),
@@ -50,9 +48,7 @@ class DocumentEditorExtension:
         )
 
     @asynccontextmanager
-    async def lock_document_edits(
-        self, ctx: ConversationContext
-    ) -> AsyncGenerator[None, None]:
+    async def lock_document_edits(self, ctx: ConversationContext) -> AsyncGenerator[None, None]:
         """
         Lock the document for editing and return a context manager that will unlock the document when exited.
         """

--- a/libraries/python/assistant-extensions/assistant_extensions/document_editor/_inspector.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/document_editor/_inspector.py
@@ -42,15 +42,9 @@ def document_list_model(documents: list[DocumentFileStateModel]) -> type[BaseMod
     )
 
 
-def _get_document_editor_ui_schema(
-    readonly: bool, documents: list[DocumentFileStateModel]
-) -> dict[str, Any]:
+def _get_document_editor_ui_schema(readonly: bool, documents: list[DocumentFileStateModel]) -> dict[str, Any]:
     schema = get_ui_schema(DocumentFileStateModel)
-    multiple_files_message = (
-        "To edit another document, switch to the Documents tab."
-        if len(documents) > 1
-        else ""
-    )
+    multiple_files_message = "To edit another document, switch to the Documents tab." if len(documents) > 1 else ""
     schema = deepmerge.always_merger.merge(
         schema.copy(),
         {
@@ -65,9 +59,7 @@ def _get_document_editor_ui_schema(
     return schema
 
 
-def _get_document_list_ui_schema(
-    model: type[BaseModel], filenames: list[str]
-) -> dict[str, Any]:
+def _get_document_list_ui_schema(model: type[BaseModel], filenames: list[str]) -> dict[str, Any]:
     return {
         "ui:options": {
             "collapsible": False,
@@ -88,18 +80,10 @@ def _get_document_list_ui_schema(
 class InspectorController(Protocol):
     async def is_enabled(self, context: ConversationContext) -> bool: ...
     async def is_read_only(self, context: ConversationContext) -> bool: ...
-    async def read_active_document(
-        self, context: ConversationContext
-    ) -> DocumentFileStateModel | None: ...
-    async def write_active_document(
-        self, context: ConversationContext, content: str
-    ) -> None: ...
-    async def set_active_filename(
-        self, context: ConversationContext, filename: str
-    ) -> None: ...
-    async def list_documents(
-        self, context: ConversationContext
-    ) -> list[DocumentFileStateModel]: ...
+    async def read_active_document(self, context: ConversationContext) -> DocumentFileStateModel | None: ...
+    async def write_active_document(self, context: ConversationContext, content: str) -> None: ...
+    async def set_active_filename(self, context: ConversationContext, filename: str) -> None: ...
+    async def list_documents(self, context: ConversationContext) -> list[DocumentFileStateModel]: ...
 
 
 class EditableDocumentFileStateInspector:
@@ -129,9 +113,7 @@ class EditableDocumentFileStateInspector:
     def description(self) -> str:
         return self._description
 
-    async def get(
-        self, context: ConversationContext
-    ) -> AssistantConversationInspectorStateDataModel:
+    async def get(self, context: ConversationContext) -> AssistantConversationInspectorStateDataModel:
         if not await self._controller.is_enabled(context):
             return AssistantConversationInspectorStateDataModel(
                 data={"content": "The Document Editor extension is not enabled."}
@@ -139,9 +121,7 @@ class EditableDocumentFileStateInspector:
 
         document = await self._controller.read_active_document(context)
         if not document:
-            return AssistantConversationInspectorStateDataModel(
-                data={"content": "No current document."}
-            )
+            return AssistantConversationInspectorStateDataModel(data={"content": "No current document."})
 
         return AssistantConversationInspectorStateDataModel(
             data=document.model_dump(mode="json"),
@@ -198,9 +178,7 @@ class ReadonlyDocumentFileStateInspector:
     def description(self) -> str:
         return self._description
 
-    async def get(
-        self, context: ConversationContext
-    ) -> AssistantConversationInspectorStateDataModel:
+    async def get(self, context: ConversationContext) -> AssistantConversationInspectorStateDataModel:
         if not await self._controller.is_enabled(context):
             return AssistantConversationInspectorStateDataModel(
                 data={"content": "The Document Editor extension is not enabled."}
@@ -208,14 +186,10 @@ class ReadonlyDocumentFileStateInspector:
 
         document = await self._controller.read_active_document(context)
         if not document:
-            return AssistantConversationInspectorStateDataModel(
-                data={"content": "No current document."}
-            )
+            return AssistantConversationInspectorStateDataModel(data={"content": "No current document."})
 
         return AssistantConversationInspectorStateDataModel(
-            data={
-                "content": f"```markdown\n_Filename: {document.filename}_\n\n{document.content}\n```"
-            }
+            data={"content": f"```markdown\n_Filename: {document.filename}_\n\n{document.content}\n```"}
         )
 
 
@@ -246,9 +220,7 @@ class DocumentListInspector:
     def description(self) -> str:
         return self._description
 
-    async def get(
-        self, context: ConversationContext
-    ) -> AssistantConversationInspectorStateDataModel:
+    async def get(self, context: ConversationContext) -> AssistantConversationInspectorStateDataModel:
         if not await self._controller.is_enabled(context):
             return AssistantConversationInspectorStateDataModel(
                 data={"content": "The Document Editor extension is not enabled."}
@@ -256,25 +228,18 @@ class DocumentListInspector:
 
         documents = await self._controller.list_documents(context)
         if not documents:
-            return AssistantConversationInspectorStateDataModel(
-                data={"content": "No documents available."}
-            )
+            return AssistantConversationInspectorStateDataModel(data={"content": "No documents available."})
 
         filenames = [document.filename for document in documents]
         model = document_list_model(documents)
 
         current_document = await self._controller.read_active_document(context)
-        selected_filename = (
-            current_document.filename if current_document else filenames[0]
-        )
+        selected_filename = current_document.filename if current_document else filenames[0]
 
         return AssistantConversationInspectorStateDataModel(
             data={
                 "attachments": [
-                    DocumentFileStateModel.model_validate(document).model_dump(
-                        mode="json"
-                    )
-                    for document in documents
+                    DocumentFileStateModel.model_validate(document).model_dump(mode="json") for document in documents
                 ],
                 "active_document": selected_filename,
             },
@@ -314,9 +279,7 @@ class DocumentInspectors:
             display_name="Documents",
             description="Download a document:",
         )
-        app.add_inspector_state_provider(
-            state_id=self._file_list.state_id, provider=self._file_list
-        )
+        app.add_inspector_state_provider(state_id=self._file_list.state_id, provider=self._file_list)
 
         self._viewer = ReadonlyDocumentFileStateInspector(
             controller=self,
@@ -330,9 +293,7 @@ class DocumentInspectors:
             controller=self,
             display_name="Document Editor",
         )
-        app.add_inspector_state_provider(
-            state_id=self._editor.state_id, provider=self._editor
-        )
+        app.add_inspector_state_provider(state_id=self._editor.state_id, provider=self._editor)
 
         @app.events.conversation.participant.on_updated_including_mine
         async def on_participant_update(
@@ -371,9 +332,7 @@ class DocumentInspectors:
                 )
             )
 
-    async def on_external_write(
-        self, context: ConversationContext, filename: str
-    ) -> None:
+    async def on_external_write(self, context: ConversationContext, filename: str) -> None:
         self._selected_file[context.id] = filename
         await context.send_conversation_state_event(
             workbench_model.AssistantStateEvent(
@@ -390,13 +349,9 @@ class DocumentInspectors:
     async def is_read_only(self, context: ConversationContext) -> bool:
         return context.id in self._readonly
 
-    async def read_active_document(
-        self, context: ConversationContext
-    ) -> DocumentFileStateModel | None:
+    async def read_active_document(self, context: ConversationContext) -> DocumentFileStateModel | None:
         drive = self._drive_provider(context)
-        markdown_files = [
-            filename for filename in drive.list() if filename.endswith(".md")
-        ]
+        markdown_files = [filename for filename in drive.list() if filename.endswith(".md")]
         if not markdown_files:
             self._selected_file.pop(context.id, None)
             return None
@@ -417,9 +372,7 @@ class DocumentInspectors:
 
         return DocumentFileStateModel(content=file_content, filename=selected_file_name)
 
-    async def write_active_document(
-        self, context: ConversationContext, content: str
-    ) -> None:
+    async def write_active_document(self, context: ConversationContext, content: str) -> None:
         drive = self._drive_provider(context)
         filename = self._selected_file.get(context.id)
         if not filename:
@@ -432,13 +385,9 @@ class DocumentInspectors:
             content_type="text/markdown",
         )
 
-    async def list_documents(
-        self, context: ConversationContext
-    ) -> list[DocumentFileStateModel]:
+    async def list_documents(self, context: ConversationContext) -> list[DocumentFileStateModel]:
         drive = self._drive_provider(context)
-        markdown_files = [
-            filename for filename in drive.list() if filename.endswith(".md")
-        ]
+        markdown_files = [filename for filename in drive.list() if filename.endswith(".md")]
 
         documents = []
         for filename in markdown_files:
@@ -450,15 +399,11 @@ class DocumentInspectors:
                 continue
 
             file_content = buffer.getvalue().decode("utf-8")
-            documents.append(
-                DocumentFileStateModel(content=file_content, filename=filename)
-            )
+            documents.append(DocumentFileStateModel(content=file_content, filename=filename))
 
         return sorted(documents, key=lambda x: x.filename)
 
-    async def set_active_filename(
-        self, context: ConversationContext, filename: str
-    ) -> None:
+    async def set_active_filename(self, context: ConversationContext, filename: str) -> None:
         self._selected_file[context.id] = filename
 
         await context.send_conversation_state_event(
@@ -471,9 +416,7 @@ class DocumentInspectors:
 
 
 @asynccontextmanager
-async def lock_document_edits(
-    app: AssistantAppProtocol, context: ConversationContext
-) -> AsyncGenerator[None, None]:
+async def lock_document_edits(app: AssistantAppProtocol, context: ConversationContext) -> AsyncGenerator[None, None]:
     """
     A temporary work-around to call the event handlers directly to communicate the document lock
     status to the document inspectors. This circumvents the serialization of event delivery by

--- a/libraries/python/assistant-extensions/assistant_extensions/mcp/_assistant_file_resource_handler.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/mcp/_assistant_file_resource_handler.py
@@ -155,9 +155,7 @@ class AssistantFileResourceHandler:
             match params.contents:
                 case BlobResourceContents():
                     content_bytes = base64.b64decode(params.contents.blob)
-                    content_type = (
-                        params.contents.mimeType or "application/octet-stream"
-                    )
+                    content_type = params.contents.mimeType or "application/octet-stream"
 
                 case TextResourceContents():
                     content_bytes = params.contents.text.encode("utf-8")

--- a/libraries/python/assistant-extensions/assistant_extensions/mcp/_devtunnel.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/mcp/_devtunnel.py
@@ -20,7 +20,6 @@ class DevTunnelConfig:
     tunnel_id: str
     port: int
 
-
     def unique_tunnel_id(self) -> str:
         """Generate a unique ID for the tunnel."""
         return f"{self.tunnel_id}-{self.access_token}"
@@ -163,9 +162,7 @@ async def _create_tunnel(devtunnel: DevTunnelConfig) -> DevTunnel:
         stdout = completed_process.stdout[completed_process.stdout.index("{") :]
         output = json.loads(stdout)
     except (json.JSONDecodeError, ValueError) as e:
-        raise RuntimeError(
-            f"Failed to parse JSON output from devtunnel show: {e}"
-        ) from e
+        raise RuntimeError(f"Failed to parse JSON output from devtunnel show: {e}") from e
 
     tunnel: dict[str, Any] = output.get("tunnel")
     if not tunnel:

--- a/libraries/python/assistant-extensions/assistant_extensions/mcp/_openai_utils.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/mcp/_openai_utils.py
@@ -47,9 +47,7 @@ class OpenAISamplingHandler(SamplingHandler):
 
     def __init__(
         self,
-        ai_client_configs: list[
-            Union[AzureOpenAIClientConfigModel, OpenAIClientConfigModel]
-        ],
+        ai_client_configs: list[Union[AzureOpenAIClientConfigModel, OpenAIClientConfigModel]],
         assistant_mcp_tools: list[ChatCompletionToolParam] | None = None,
         message_processor: OpenAIMessageProcessor | None = None,
         handler: MCPSamplingMessageHandler | None = None,
@@ -60,27 +58,19 @@ class OpenAISamplingHandler(SamplingHandler):
         # set a default message processor that converts sampling messages to
         # chat completion messages and performs any necessary transformations
         # such as injecting content as replacements for placeholders, etc.
-        self.message_processor: OpenAIMessageProcessor = (
-            message_processor or self._default_message_processor
-        )
+        self.message_processor: OpenAIMessageProcessor = message_processor or self._default_message_processor
 
         # set a default handler so that it can be registered during client
         # session connection, prior to having access to the actual handler
         # allowing the handler to be set after the client session is created
         # and more context is available
-        self._message_handler: MCPSamplingMessageHandler = (
-            handler or self._default_message_handler
-        )
+        self._message_handler: MCPSamplingMessageHandler = handler or self._default_message_handler
 
-    def _default_message_processor(
-        self, messages: List[SamplingMessage]
-    ) -> List[ChatCompletionMessageParam]:
+    def _default_message_processor(self, messages: List[SamplingMessage]) -> List[ChatCompletionMessageParam]:
         """
         Default template processor that passes messages through.
         """
-        return [
-            sampling_message_to_chat_completion_message(message) for message in messages
-        ]
+        return [sampling_message_to_chat_completion_message(message) for message in messages]
 
     async def _default_message_handler(
         self,
@@ -89,9 +79,7 @@ class OpenAISamplingHandler(SamplingHandler):
     ) -> CreateMessageResult | ErrorData:
         logger.info(f"Sampling handler invoked with context: {context}")
 
-        ai_client_config = self._ai_client_config_from_model_preferences(
-            params.modelPreferences
-        )
+        ai_client_config = self._ai_client_config_from_model_preferences(params.modelPreferences)
 
         if not ai_client_config:
             raise ValueError("No AI client configs defined for sampling requests.")
@@ -183,10 +171,7 @@ class OpenAISamplingHandler(SamplingHandler):
         use_reasoning_model = intelligence_priority > speed_priority
 
         for ai_client_config in self.ai_client_configs:
-            if (
-                ai_client_config.request_config.is_reasoning_model
-                == use_reasoning_model
-            ):
+            if ai_client_config.request_config.is_reasoning_model == use_reasoning_model:
                 return ai_client_config
 
         # failing to find a config via preferences, return first config
@@ -264,9 +249,7 @@ def sampling_message_to_chat_completion_user_message(
         raise ValueError(f"Unsupported role: {sampling_message.role}")
 
     if isinstance(sampling_message.content, TextContent):
-        return ChatCompletionUserMessageParam(
-            role="user", content=sampling_message.content.text
-        )
+        return ChatCompletionUserMessageParam(role="user", content=sampling_message.content.text)
     elif isinstance(sampling_message.content, ImageContent):
         return ChatCompletionUserMessageParam(
             role="user",
@@ -294,9 +277,7 @@ def sampling_message_to_chat_completion_assistant_message(
         raise ValueError(f"Unsupported role: {sampling_message.role}")
 
     if not isinstance(sampling_message.content, TextContent):
-        raise ValueError(
-            f"Unsupported content type: {type(sampling_message.content)} for assistant"
-        )
+        raise ValueError(f"Unsupported content type: {type(sampling_message.content)} for assistant")
 
     return ChatCompletionAssistantMessageParam(
         role="assistant",
@@ -315,8 +296,6 @@ def sampling_message_to_chat_completion_message(
         case "user":
             return sampling_message_to_chat_completion_user_message(sampling_message)
         case "assistant":
-            return sampling_message_to_chat_completion_assistant_message(
-                sampling_message
-            )
+            return sampling_message_to_chat_completion_assistant_message(sampling_message)
         case _:
             raise ValueError(f"Unsupported role: {sampling_message.role}")

--- a/libraries/python/assistant-extensions/assistant_extensions/mcp/_workbench_file_resource_handler.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/mcp/_workbench_file_resource_handler.py
@@ -142,9 +142,7 @@ class WorkbenchFileClientResourceHandler:
             match params.contents:
                 case BlobResourceContents():
                     content_bytes = base64.b64decode(params.contents.blob)
-                    content_type = (
-                        params.contents.mimeType or "application/octet-stream"
-                    )
+                    content_type = params.contents.mimeType or "application/octet-stream"
 
                 case TextResourceContents():
                     content_bytes = params.contents.text.encode("utf-8")

--- a/libraries/python/assistant-extensions/pyproject.toml
+++ b/libraries/python/assistant-extensions/pyproject.toml
@@ -27,9 +27,6 @@ mcp = ["mcp-extensions[openai]>=0.1.0"]
 [dependency-groups]
 dev = ["pyright>=1.1.389", "pytest>=8.3.1", "pytest-asyncio>=0.23.8"]
 
-[tool.ruff]
-target-version = "py311"
-
 [tool.uv.sources]
 anthropic-client = { path = "../anthropic-client", editable = true }
 assistant-drive = { path = "../assistant-drive", editable = true }


### PR DESCRIPTION
By removing local ruff config, falling back to the repo-root ruff.toml.

Additionally, run a `make format` to apply the correct formatting.