### PR TITLE
Enables viewing whiteboard history by scrolling messages

### DIFF
--- a/mcp-servers/mcp-server-memory-whiteboard/mcp_server_memory_whiteboard/server.py
+++ b/mcp-servers/mcp-server-memory-whiteboard/mcp_server_memory_whiteboard/server.py
@@ -1,8 +1,10 @@
 import asyncio
+import datetime
 import logging
 import pathlib
 from textwrap import dedent
-from typing import Annotated, Any
+from typing import Annotated, Any, Iterable
+from urllib.parse import unquote
 
 import openai_client
 from mcp import ClientCapabilities, RootsCapability, ServerSession
@@ -17,6 +19,7 @@ from openai_client import (
     OpenAIRequestConfig,
     azure_openai_service_config_construct,
     completion_structured,
+    num_tokens_from_message,
 )
 from pydantic import BaseModel, Field
 from semantic_workbench_assistant.config import first_env_var
@@ -31,6 +34,7 @@ server_name = "Whiteboard Memory MCP Server"
 
 class WhiteboardStateModel(BaseModel):
     content: str = ""
+    timestamp: datetime.datetime = Field(default_factory=lambda: datetime.datetime.now(datetime.UTC))
     metadata: dict[str, Any] = {}
 
 
@@ -54,6 +58,7 @@ def create_mcp_server() -> FastMCP:
         attachment_messages: list[ChatCompletionSystemMessageParam | ChatCompletionUserMessageParam],
         chat_messages: list[ChatCompletionMessageParam],
     ) -> str:
+        mcp.get_context().session.client_params
         session_config = await get_session_config(mcp.get_context())
         await notification_queue.put(
             Notification(
@@ -70,7 +75,7 @@ def create_mcp_server() -> FastMCP:
         Whiteboard content as a prompt.
         """
         session_config = await get_session_config(mcp.get_context())
-        return (await read_whiteboard_state(session_config)).content
+        return (await read_whiteboard_state(session_config, timestamp=None)).content
 
     @mcp.resource("resource://memory/whiteboard", description="Whiteboard memory as a JSON resource")
     async def whiteboard_memory_resource() -> WhiteboardStateModel:
@@ -78,7 +83,20 @@ def create_mcp_server() -> FastMCP:
         Whiteboard memory as a JSON resource.
         """
         session_config = await get_session_config(mcp.get_context())
-        return await read_whiteboard_state(session_config)
+        return await read_whiteboard_state(session_config, timestamp=None)
+
+    @mcp.resource(
+        "resource://memory/whiteboard/{timestamp}",
+        description="Whiteboard memory as a JSON resource, as of the given timestamp",
+    )
+    async def whiteboard_memory_resource_by_timestamp(timestamp: str) -> WhiteboardStateModel:
+        """
+        Whiteboard memory as a JSON resource, as of the given timestamp.
+        """
+        decoded_timestamp = unquote(timestamp)
+        timestamp_datetime = datetime.datetime.fromisoformat(decoded_timestamp)
+        session_config = await get_session_config(mcp.get_context())
+        return await read_whiteboard_state(session_config, timestamp=timestamp_datetime)
 
     return mcp
 
@@ -103,15 +121,46 @@ async def get_session_config(ctx: Context[ServerSession, object]) -> SessionConf
     return SessionConfig(session_id=session_id)
 
 
-def path_for_whiteboard(session_config: SessionConfig) -> pathlib.Path:
-    return pathlib.Path(storage.settings.root) / session_config.session_id / "whiteboard.json"
+def path_for_directory(session_config: SessionConfig) -> pathlib.Path:
+    """
+    Get the path for the directory where the whiteboard state is stored.
+    """
+    return pathlib.Path(storage.settings.root) / session_config.session_id
 
 
-async def read_whiteboard_state(session_config: SessionConfig) -> WhiteboardStateModel:
+def timestamp_to_filename(timestamp: datetime.datetime) -> str:
+    """
+    Convert a timestamp to a filename.
+    """
+    return f"{timestamp.isoformat().replace(':', '-').replace('+', '--')}.json"
+
+
+async def read_whiteboard_state(
+    session_config: SessionConfig, timestamp: datetime.datetime | None
+) -> WhiteboardStateModel:
     """
     Read the whiteboard state from the storage.
     """
-    whiteboard_path = path_for_whiteboard(session_config)
+    whiteboard_path = path_for_directory(session_config) / "latest.json"
+    if timestamp:
+        first_timestamp_after = ""
+        first_timestamp_before = ""
+        for file in path_for_directory(session_config).glob("*.json"):
+            if file.name == "latest.json":
+                continue
+
+            if file.name <= timestamp_to_filename(timestamp):
+                if not first_timestamp_before or file.name > first_timestamp_before:
+                    first_timestamp_before = file.name
+                continue
+
+            if file.name > timestamp_to_filename(timestamp):
+                if not first_timestamp_after or file.name < first_timestamp_after:
+                    first_timestamp_after = file.name
+
+        if first_timestamp_after or first_timestamp_before:
+            whiteboard_path = path_for_directory(session_config) / (first_timestamp_after or first_timestamp_before)
+
     state = storage.read_model(file_path=whiteboard_path, cls=WhiteboardStateModel) or WhiteboardStateModel()
     return state
 
@@ -120,8 +169,10 @@ async def write_whiteboard_state(session_config: SessionConfig, state: Whiteboar
     """
     Write the whiteboard state to the storage.
     """
-    whiteboard_path = path_for_whiteboard(session_config)
-    storage.write_model(file_path=whiteboard_path, value=state)
+    latest_path = path_for_directory(session_config) / "latest.json"
+    timestamp_path = path_for_directory(session_config) / timestamp_to_filename(state.timestamp)
+    storage.write_model(file_path=latest_path, value=state)
+    storage.write_model(file_path=timestamp_path, value=state)
 
 
 async def process_notification_queue(notification_queue: asyncio.Queue[Notification]) -> None:
@@ -150,105 +201,93 @@ async def process_notification(notification: Notification) -> None:
     class WhiteboardModel(BaseModel):
         content: Annotated[str, Field(description="Content of the whiteboard")]
 
-    current_whiteboard_state = await read_whiteboard_state(notification.session_config)
+    current_whiteboard_state = await read_whiteboard_state(notification.session_config, None)
 
-    attachment_completion_messages = []
-    for message in notification.attachment_messages:
+    model = first_env_var("azure_openai_model", "assistant__azure_openai_model") or "gpt-4.1"
+
+    max_chat_token_count = 1024 * 6  # 6k tokens, similar to the v5 whiteboard limitations
+
+    token_count = 0
+    chat_completion_messages: list[ChatCompletionMessageParam] = []
+
+    for message in reversed(notification.chat_messages):
+        # remove the tool calls from the message
+        message.pop("tool_calls", None)
+        # ignore all tool call response messages
+        if message["role"] == "tool":
+            continue
+
         content = message.get("content")
-        if not content:
-            continue
+        match content:
+            case str():
+                completion_message = message
 
-        if isinstance(content, str):
-            attachment_completion_messages.append({
-                "role": "user",
-                "content": content,
-            })
-            continue
+            case Iterable():
+                # the contents with iterables are parsed as pydantic ValidationIterator
+                # (not sure why - i think it is something that the mcp library does)
+                # for these, we need to convert them back to a list
+                completion_message = {
+                    "role": "user",
+                    "content": [part for part in content],
+                }
 
-        attachment_completion_messages.append({
-            "role": "user",
-            "content": [part for part in content],
-        })
+            case _:
+                continue
 
-    chat_completion_messages = []
-    for message in notification.chat_messages:
-        content = message.get("content")
-        if not content:
-            continue
+        message_tokens = num_tokens_from_message(message, model=model)
 
-        if isinstance(content, str):
-            chat_completion_messages.append({
-                "role": "user",
-                "content": content,
-            })
-            continue
+        token_count += message_tokens
+        if token_count > max_chat_token_count:
+            break
 
-        chat_completion_messages.append({
-            "role": "user",
-            "content": [part for part in content],
-        })
+        chat_completion_messages.append(completion_message)  # type: ignore
+
+    chat_completion_messages = list(reversed(chat_completion_messages))
 
     completion_messages = [
-        *attachment_completion_messages,
-        *notification.chat_messages,
-        # {
-        #     "role": "user",
-        #     "content": "<CHAT_HISTORY>\n"
-        #     + "\n".join([
-        #         str(message.get("content")) for message in notification.chat_messages if message.get("content")
-        #     ])
-        #     + "\n</CHAT_HISTORY>",
-        # },
+        *chat_completion_messages,
         {
             "role": "developer",
             "content": dedent(
                 """
-                You are an expert note-taker and whiteboard manager. You are responsible for keeping the
-                whiteboard up to date with the most important information from the <CHAT_HISTORY>. The
-                whiteboard is a summary of the most important information that is relevant to the current
-                task at hand. It is not a transcript of the conversation, but rather only the most
-                important information that is relevant to the current task at hand.
+                Extract important information from the chat history between the assistant and user(s). It should be used to update the whiteboard content for the assistant.
 
-                The whiteboard is limited in size, so it is important to keep it up to date with the most
-                important information and it is ok to remove information that is no longer relevant. It is
-                also ok to leave the whiteboard blank if there is no information important enough to be added
-                to the whiteboard.
+                The assistant has access to look up information in the rest of the chat history, but this is based upon semantic similarity to current user request, so the whiteboard content is for information that should always be available to the bot, even if it is not directly semantically related to the current user request.
 
-                Think of the whiteboard as the type of content that might be written down on a whiteboard
-                during a meeting. It is not a transcript of the conversation, but rather only the most
-                important information that is relevant to the current task at hand.
+                The whiteboard is limited in size, so it is important to keep it up to date with the most important information and it is ok to remove information that is no longer relevant.  It is also ok to leave the whiteboard blank if there is no information important enough be added to the whiteboard.
 
-                Use markdown to format the whiteboard content. For example, you can use headings, lists,
-                and links to other resources.
+                Think of the whiteboard as the type of content that might be written down on a whiteboard during a meeting. It is not a transcript of the conversation, but rather only the most important information that is relevant to the current task at hand.
 
-                Please provide updated whiteboard content based upon the current whiteboard and relevant
-                information extracted from the <CHAT_HISTORY>.
+                Use markdown to format the whiteboard content.  For example, you can use headings, lists, and links to other resources.
 
-                - DO include decisions made, if any
-                - DO include historical tasks
-                - DO include historical decisions, unless they have been superseded with new decisions
-                - DO NOT include any information that is not in the <CHAT_HISTORY>
-                - DO NOT suggest next steps or actions
-                - DO NOT answer any questions
-
-                The current whiteboard content, which you will be updating, is as follows:
+                Whiteboard content:
                 <WHITEBOARD>
-                """
-                + current_whiteboard_state.content
-                + """
+                {current_whiteboard}
                 </WHITEBOARD>
-
-                Now go ahead and do you job and give me the updated whiteboard content.
+                """
+            )
+            .strip()
+            .format(
+                current_whiteboard=current_whiteboard_state.content,
+            ),
+        },
+        {
+            "role": "developer",
+            "content": dedent(
+                """
+                Please provide updated whiteboard content based upon information extracted from the chat history.  Do not provide any information that is not already in the chat history and do not answer any pending requests.
                 """
             ).strip(),
         },
     ]
 
-    service_config = azure_openai_service_config_construct(default_deployment="gpt-4o")
+    service_config = azure_openai_service_config_construct(default_deployment=model)
     request_config = OpenAIRequestConfig(
         max_tokens=128_000,
-        response_tokens=8196,
-        model=first_env_var("azure_openai_model", "assistant__azure_openai_model") or "gpt-4o",
+        # artificially limit the response tokens to 1k to limit the size of the whiteboard
+        # and match the v5 whiteboard implementation
+        response_tokens=1024,
+        model=model,
     )
     try:
         async with openai_client.create_client(service_config=service_config) as client:

--- a/workbench-app/src/components/Conversations/Message/InteractMessage.tsx
+++ b/workbench-app/src/components/Conversations/Message/InteractMessage.tsx
@@ -92,11 +92,13 @@ interface InteractMessageProps {
     displayDate?: boolean;
     readOnly: boolean;
     onRead?: (message: ConversationMessage) => void;
+    onVisible?: (message: ConversationMessage) => void;
     onRewind?: (message: ConversationMessage, redo: boolean) => void;
 }
 
 export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
-    const { conversation, message, participant, hideParticipant, displayDate, readOnly, onRead, onRewind } = props;
+    const { conversation, message, participant, hideParticipant, displayDate, readOnly, onRead, onVisible, onRewind } =
+        props;
     const classes = useClasses();
     const { isMessageVisible, isMessageVisibleRef, isUnread } = useConversationUtility();
 
@@ -104,12 +106,16 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
     const date = Utility.toFormattedDateString(message.timestamp, 'dddd, MMMM D');
 
     React.useEffect(() => {
-        // Check if the message is visible and unread. If so, trigger the onRead handler to mark it read.
-        // If the message is visible, mark it as read by invoking the onRead handler.
-        if (isMessageVisible && isUnread(conversation, message.timestamp)) {
-            onRead?.(message);
+        if (isMessageVisible) {
+            onVisible?.(message);
+
+            // Check if the message is visible and unread. If so, trigger the onRead handler to mark it read.
+            // If the message is visible, mark it as read by invoking the onRead handler.
+            if (isUnread(conversation, message.timestamp)) {
+                onRead?.(message);
+            }
         }
-    }, [isMessageVisible, isUnread, message.timestamp, onRead, conversation, message]);
+    }, [isMessageVisible, isUnread, message.timestamp, onRead, onVisible, conversation, message]);
 
     const header = hideParticipant ? null : (
         <MessageHeader

--- a/workbench-app/src/services/workbench/participant.ts
+++ b/workbench-app/src/services/workbench/participant.ts
@@ -25,7 +25,8 @@ const participantApi = workbenchApi.injectEndpoints({
                 method: 'PUT',
                 body: { status, active_participant: true, metadata },
             }),
-            invalidatesTags: ['Conversation'],
+            // This mutation should not invalidate the conversation query because it does not add or remove participants
+            invalidatesTags: [],
         }),
         removeConversationParticipant: builder.mutation<void, { conversationId: string; participantId: string }>({
             query: ({ conversationId, participantId }) => ({


### PR DESCRIPTION
- app updates the participant metadata with the timestamp of the message currently in view
- extension listens for participant update events, and requests the most recent whiteboard on or before that timestamp
- whiteboard MCP server saves all whiteboard versions with timestamps
- whiteboard MCP server supports requesting whiteboards by timestamp