### PR TITLE
Navigator can present assistant cards

### DIFF
--- a/assistants/navigator-assistant/assistant/response/local_tool/add_assistant_to_conversation.py
+++ b/assistants/navigator-assistant/assistant/response/local_tool/add_assistant_to_conversation.py
@@ -2,6 +2,7 @@ import asyncio
 
 from pydantic import BaseModel
 from semantic_workbench_api_model.workbench_model import (
+    MessageType,
     NewConversationMessage,
 )
 from semantic_workbench_assistant.assistant_app import ConversationContext
@@ -12,34 +13,25 @@ from .model import LocalTool
 class ArgumentModel(BaseModel):
     assistant_service_id: str
     template_id: str
-    name: str
 
 
-async def add_assistant_to_conversation(args: ArgumentModel, context: ConversationContext) -> str:
+async def assistant_card(args: ArgumentModel, context: ConversationContext) -> str:
     """
-    Tool to add an assistant to the conversation. Results in a conversation message that renders as a button
-    for the user to click. The button will add the assistant to the conversation.
+    Tool to render a control that allows the user to create a new conversation with an assistant.
+    Results in the app rendering an assistant card with a create buttton.
+    The button will create a new conversation with the assistant.
     """
 
     async def send_it() -> None:
         await asyncio.sleep(2)
         await context.send_messages(
             NewConversationMessage(
-                content="{}",
-                content_type="application/json",
+                message_type=MessageType.note,
+                content="Click the button below to add the assistant to the conversation.",
                 metadata={
-                    "json_schema": {},
-                    "ui_schema": {
-                        "ui:options": {
-                            "title": "Add an assistant to the conversation",
-                            "submitButtonOptions": {
-                                "submitText": f"Add {args.name}",
-                            },
-                        },
-                    },
-                    "appAction": {
-                        "action": "addAssistant",
-                        "arguments": {
+                    "_appComponent": {
+                        "type": "AssistantCard",
+                        "props": {
                             "assistantServiceId": args.assistant_service_id,
                             "templateId": args.template_id,
                         },
@@ -50,7 +42,7 @@ async def add_assistant_to_conversation(args: ArgumentModel, context: Conversati
 
     asyncio.create_task(send_it())
 
-    return "Success: The user will be presented with a button to add the assistant to the conversation."
+    return "Success: The user will be presented with an assistant card to create a new conversation with the assistant."
 
 
-tool = LocalTool(name="add_assistant_to_conversation", argument_model=ArgumentModel, func=add_assistant_to_conversation)
+tool = LocalTool(name="assistant_card", argument_model=ArgumentModel, func=assistant_card)

--- a/assistants/navigator-assistant/assistant/response/response.py
+++ b/assistants/navigator-assistant/assistant/response/response.py
@@ -25,6 +25,7 @@ from semantic_workbench_api_model.workbench_model import (
 from semantic_workbench_assistant.assistant_app import ConversationContext
 
 from ..config import AssistantConfigModel
+from .local_tool import add_assistant_to_conversation_tool
 from .local_tool.list_assistant_services import get_assistant_services
 from .step_handler import next_step
 from .utils import get_ai_client_configs
@@ -143,7 +144,7 @@ async def respond_to_conversation(
                 attachments_config=config.extensions_config.attachments,
                 metadata=metadata,
                 metadata_key=f"respond_to_conversation:step_{step_count}",
-                local_tools=[],
+                local_tools=[add_assistant_to_conversation_tool],
                 system_message_content=combined_prompt(
                     config.prompts.instruction_prompt,
                     'Your name is "{context.assistant.name}".',

--- a/workbench-app/src/components/Conversations/Message/ContentRenderer.tsx
+++ b/workbench-app/src/components/Conversations/Message/ContentRenderer.tsx
@@ -8,6 +8,7 @@ import {
 import React from 'react';
 import { Conversation } from '../../../models/Conversation';
 import { ConversationMessage } from '../../../models/ConversationMessage';
+import { AssistantCard } from '../../FrontDoor/Controls/AssistantCard';
 import { MessageContent } from './MessageContent';
 
 interface ContentRendererProps {
@@ -17,6 +18,22 @@ interface ContentRendererProps {
 
 export const ContentRenderer: React.FC<ContentRendererProps> = (props) => {
     const { conversation, message } = props;
+
+    const appComponent = message.metadata?._appComponent;
+    if (appComponent) {
+        switch (appComponent.type) {
+            case 'AssistantCard':
+                return (
+                    <AssistantCard
+                        assistantServiceId={appComponent.props.assistantServiceId}
+                        templateId={appComponent.props.templateId}
+                        hideContent
+                    />
+                );
+            default:
+                return null;
+        }
+    }
 
     const messageContent = <MessageContent message={message} conversation={conversation} />;
 

--- a/workbench-app/src/components/FrontDoor/Controls/AssistantCard.tsx
+++ b/workbench-app/src/components/FrontDoor/Controls/AssistantCard.tsx
@@ -1,0 +1,247 @@
+import {
+    Button,
+    Card,
+    CardHeader,
+    CardPreview,
+    makeStyles,
+    Menu,
+    MenuButtonProps,
+    MenuItem,
+    MenuList,
+    MenuPopover,
+    MenuTrigger,
+    SplitButton,
+    Title3,
+    tokens,
+} from '@fluentui/react-components';
+import { ChatAdd24Regular } from '@fluentui/react-icons';
+import React from 'react';
+import { useConversationUtility } from '../../../libs/useConversationUtility';
+import { useCreateConversation } from '../../../libs/useCreateConversation';
+import { Assistant } from '../../../models/Assistant';
+import { useGetAssistantServiceInfosQuery } from '../../../services/workbench';
+import { MarkdownContentRenderer } from '../../Conversations/ContentRenderers/MarkdownContentRenderer';
+
+interface CardContent {
+    contentType: string;
+    content: string;
+}
+
+interface DashboardCardConfig {
+    assistantServiceId: string;
+    templateId: string;
+    name: string;
+    backgroundColor: string;
+    cardContent: CardContent;
+    icon: string;
+}
+
+const useClasses = makeStyles({
+    card: {
+        padding: 0,
+        width: '420px',
+    },
+    cardHeader: {
+        padding: tokens.spacingHorizontalM,
+        borderRadius: tokens.borderRadiusMedium,
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
+    },
+    cardHeaderNoContent: {
+        padding: tokens.spacingHorizontalM,
+        borderRadius: tokens.borderRadiusMedium,
+    },
+    cardHeaderBody: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        boxSizing: 'border-box',
+        width: '100%',
+    },
+    cardPreview: {
+        padding: tokens.spacingHorizontalM,
+        paddingBottom: tokens.spacingVerticalL,
+        margin: '0 !important',
+        width: '100%',
+        boxSizing: 'border-box',
+        wordWrap: 'break-word',
+        overflowWrap: 'break-word',
+        '& ul': {
+            boxSizing: 'border-box',
+        },
+    },
+});
+
+interface AssistantCardProps {
+    assistantServiceId: string;
+    templateId: string;
+    hideContent?: boolean;
+}
+
+export const AssistantCard: React.FC<AssistantCardProps> = (props) => {
+    const { assistantServiceId, templateId, hideContent } = props;
+    const { isFetching: createConversationIsFetching, assistants } = useCreateConversation();
+    const {
+        data: assistantServices,
+        isLoading: assistantServicesIsLoading,
+        isError: assistantServicesIsError,
+    } = useGetAssistantServiceInfosQuery({ userIds: ['me'] });
+    const { navigateToConversation } = useConversationUtility();
+    const { createConversation } = useCreateConversation();
+    const [submitted, setSubmitted] = React.useState(false);
+
+    const classes = useClasses();
+
+    const createConversationWithAssistant = React.useCallback(
+        (assistantId: string) => {
+            return async () => {
+                setSubmitted(true);
+                try {
+                    const { conversation } = await createConversation({ assistantId });
+                    navigateToConversation(conversation.id);
+                } finally {
+                    setSubmitted(false);
+                }
+            };
+        },
+        [createConversation, navigateToConversation],
+    );
+
+    const quickAssistantCreateButton = React.useCallback(
+        (assistants: Assistant[]) => {
+            if (assistants.length === 0) {
+                return null;
+            }
+
+            if (assistants.length === 1) {
+                return (
+                    <Button
+                        onClick={createConversationWithAssistant(assistants[0].id)}
+                        disabled={submitted}
+                        icon={<ChatAdd24Regular />}
+                    ></Button>
+                );
+            }
+
+            return (
+                <Menu positioning="below-end">
+                    <MenuTrigger disableButtonEnhancement>
+                        {(triggerProps: MenuButtonProps) => (
+                            <SplitButton
+                                menuButton={triggerProps}
+                                primaryActionButton={{
+                                    onClick: createConversationWithAssistant(assistants[0].id),
+                                }}
+                                disabled={submitted}
+                                icon={<ChatAdd24Regular />}
+                            ></SplitButton>
+                        )}
+                    </MenuTrigger>
+
+                    <MenuPopover>
+                        <MenuList>
+                            {assistants.map((assistant) => (
+                                <MenuItem
+                                    key={assistant.id}
+                                    onClick={createConversationWithAssistant(assistant.id)}
+                                    disabled={submitted}
+                                >
+                                    {assistant.name}
+                                </MenuItem>
+                            ))}
+                        </MenuList>
+                    </MenuPopover>
+                </Menu>
+            );
+        },
+        [createConversationWithAssistant, submitted],
+    );
+
+    const assistantInstances = React.useMemo(() => {
+        if (createConversationIsFetching) {
+            return [];
+        }
+
+        const matches = assistants?.filter(
+            (assistant) => assistant.assistantServiceId === assistantServiceId && assistant.templateId === templateId,
+        );
+
+        if (matches && matches.length > 0) {
+            return matches;
+        }
+        return [];
+    }, [assistantServiceId, assistants, createConversationIsFetching, templateId]);
+
+    const dashboardCard: DashboardCardConfig | undefined = React.useMemo(() => {
+        if (
+            assistantServicesIsLoading ||
+            assistantServicesIsError ||
+            !assistantServices ||
+            !assistantInstances ||
+            assistantInstances.length === 0
+        ) {
+            return undefined;
+        }
+        const service = assistantServices.find(
+            (service) =>
+                service.metadata._dashboard_card &&
+                service.assistantServiceId === assistantServiceId &&
+                service.metadata._dashboard_card[templateId] &&
+                service.metadata._dashboard_card[templateId].enabled,
+        );
+
+        if (!service) {
+            return undefined;
+        }
+        const templateConfig = service.metadata._dashboard_card[templateId];
+        const cardConfig = {
+            templateId: templateId,
+            assistantServiceId: service.assistantServiceId,
+            name: service.templates.find((template) => template.id === templateId)?.name || service.assistantServiceId,
+            icon: templateConfig.icon,
+            backgroundColor: templateConfig.background_color,
+            cardContent: {
+                contentType: templateConfig.card_content.content_type,
+                content: templateConfig.card_content.content,
+            },
+        };
+        return cardConfig;
+    }, [
+        assistantServicesIsLoading,
+        assistantServicesIsError,
+        assistantServices,
+        assistantInstances,
+        templateId,
+        assistantServiceId,
+    ]);
+
+    if (!dashboardCard) {
+        return null;
+    }
+
+    return (
+        <Card className={classes.card} appearance="filled">
+            <CardHeader
+                image={<img src={dashboardCard.icon} alt="Assistant Icon" />}
+                header={
+                    <div className={classes.cardHeaderBody}>
+                        <Title3>{dashboardCard.name}</Title3>
+
+                        {quickAssistantCreateButton(assistantInstances)}
+                    </div>
+                }
+                className={hideContent ? classes.cardHeaderNoContent : classes.cardHeader}
+                style={{ backgroundColor: dashboardCard.backgroundColor }}
+            ></CardHeader>
+            {!hideContent && (
+                <CardPreview className={classes.cardPreview}>
+                    {dashboardCard.cardContent.contentType === 'text/markdown' ? (
+                        <MarkdownContentRenderer content={dashboardCard.cardContent.content} />
+                    ) : (
+                        dashboardCard.cardContent.content
+                    )}
+                </CardPreview>
+            )}
+        </Card>
+    );
+};

--- a/workbench-app/src/routes/FrontDoor.tsx
+++ b/workbench-app/src/routes/FrontDoor.tsx
@@ -1,4 +1,13 @@
-import { Button, Drawer, DrawerBody, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
+import {
+    Button,
+    Drawer,
+    DrawerBody,
+    Link,
+    makeStyles,
+    mergeClasses,
+    shorthands,
+    tokens,
+} from '@fluentui/react-components';
 import { ChatAddRegular, PanelLeftContractRegular, PanelLeftExpandRegular } from '@fluentui/react-icons';
 import React from 'react';
 import { useDispatch } from 'react-redux';
@@ -123,7 +132,11 @@ export const FrontDoor: React.FC = () => {
     }, [navigate]);
 
     const newConversationButton = React.useMemo(
-        () => <Button title="New Conversation" icon={<ChatAddRegular />} onClick={handleNewConversation} />,
+        () => (
+            <Link href="/" onClick={(event) => event.preventDefault()}>
+                <Button title="New Conversation" icon={<ChatAddRegular />} onClick={handleNewConversation} />
+            </Link>
+        ),
         [handleNewConversation],
     );
 


### PR DESCRIPTION
To give the user a shortcut to starting a conversation with an assistant. This is done with a special message metadata of `_appComponent`. The `type` field is the name of the component. The `AssistantCard` is currently the only supported one. The component props are provided in the `props` field.