### PR TITLE
Fix bug in rendering many messages from sender

### DIFF
--- a/workbench-app/src/components/Conversations/Message/InteractMessage.tsx
+++ b/workbench-app/src/components/Conversations/Message/InteractMessage.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-import { MessageBase } from './MessageBase';
-
 import { CopilotMessageV2, Timestamp, UserMessageV2 } from '@fluentui-copilot/react-copilot';
 import { Divider, makeStyles, mergeClasses, shorthands, tokens } from '@fluentui/react-components';
 import React from 'react';
@@ -157,15 +155,13 @@ export const InteractMessage: React.FC<InteractMessageProps> = (props) => {
                 {body}
                 <ToolCalls message={message} />
             </CopilotMessageV2>
-        ) : !hideParticipant ? (
+        ) : (
             <div className={classes.user}>
                 {header}
                 <UserMessageV2 className={classes.userContent}>{body}</UserMessageV2>
                 {actions}
                 {footer}
             </div>
-        ) : (
-            <MessageBase className={classes.note} header={header} body={body} footer={footer} />
         );
 
     return (


### PR DESCRIPTION
Fix code that intended to hide the participant header for multiple messages from a sender within a minute