### PR TITLE
Simplifies message querying

### DIFF
--- a/workbench-app/src/Constants.ts
+++ b/workbench-app/src/Constants.ts
@@ -22,7 +22,6 @@ export const Constants = {
             return `calc(100vw - ${this.conversationListMinWidth} - ${this.conversationHistoryMinWidth})`;
         },
         defaultChatWidthPercent: 33,
-        maxMessagesPerRequest: 500,
         maxFileAttachmentsPerMessage: 10,
         loaderDelayMs: 100,
         responsiveBreakpoints: {

--- a/workbench-app/src/components/Conversations/InteractInput.tsx
+++ b/workbench-app/src/components/Conversations/InteractInput.tsx
@@ -314,7 +314,7 @@ export const InteractInput: React.FC<InteractInputProps> = (props) => {
             // need to define the extra fields for the message such as sender, timestamp, etc.
             // so that the message can be rendered correctly
             dispatch(
-                updateGetConversationMessagesQueryData(conversation.id, [
+                updateGetConversationMessagesQueryData({ conversationId: conversation.id }, [
                     ...(messages ?? []),
                     {
                         id: 'optimistic',

--- a/workbench-app/src/libs/useWorkbenchService.ts
+++ b/workbench-app/src/libs/useWorkbenchService.ts
@@ -7,7 +7,6 @@ import { AssistantServiceInfo } from '../models/AssistantServiceInfo';
 import { AssistantServiceRegistration } from '../models/AssistantServiceRegistration';
 import { Conversation } from '../models/Conversation';
 import { ConversationFile } from '../models/ConversationFile';
-import { ConversationMessage } from '../models/ConversationMessage';
 import { ConversationParticipant } from '../models/ConversationParticipant';
 import { useAppDispatch } from '../redux/app/hooks';
 import { addError } from '../redux/features/app/appSlice';
@@ -155,29 +154,11 @@ export const useWorkbenchService = () => {
             conversation: Conversation,
             participants: ConversationParticipant[],
         ): Promise<{ blob: Blob; filename: string }> => {
-            const messages: ConversationMessage[] = [];
-            let before_message_id: string | undefined = undefined;
-
-            while (true) {
-                try {
-                    const new_messages = await dispatch(
-                        conversationApi.endpoints.getConversationMessages.initiate({
-                            conversationId: conversation.id,
-                            before: before_message_id,
-                        }),
-                    ).unwrap();
-
-                    if (new_messages.length === 0) {
-                        break;
-                    }
-
-                    messages.unshift(...new_messages);
-                    before_message_id = new_messages[0].id;
-                } catch (error) {
-                    dispatch(addError({ title: 'Export transcript', message: (error as Error).message }));
-                    throw error;
-                }
-            }
+            const messages = await dispatch(
+                conversationApi.endpoints.getConversationMessages.initiate({
+                    conversationId: conversation.id,
+                }),
+            ).unwrap();
 
             const timestampForFilename = Utility.getTimestampForFilename();
             const filename = `transcript_${conversation.title.replaceAll(' ', '_')}_${timestampForFilename}.md`;

--- a/workbench-app/src/redux/features/app/appSlice.ts
+++ b/workbench-app/src/redux/features/app/appSlice.ts
@@ -4,7 +4,7 @@ import { generateUuid } from '@azure/ms-rest-js';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { Constants } from '../../../Constants';
 import { AppStorage } from '../../../libs/AppStorage';
-import { conversationApi } from '../../../services/workbench';
+import { workbenchApi } from '../../../services/workbench';
 import { AppState } from './AppState';
 
 const localStorageKey = {
@@ -95,10 +95,7 @@ export const appSlice = createSlice({
 
             // dispatch to invalidate messages cache
             if (action.payload) {
-                conversationApi.endpoints.getConversationMessages.initiate(
-                    { conversationId: action.payload },
-                    { forceRefetch: true },
-                );
+                workbenchApi.util.invalidateTags(['ConversationMessage']);
             }
         },
         setGlobalContentOpen: (state: AppState, action: PayloadAction<boolean>) => {

--- a/workbench-app/src/services/workbench/workbench.ts
+++ b/workbench-app/src/services/workbench/workbench.ts
@@ -71,6 +71,7 @@ export const workbenchApi = createApi({
         'ConversationShare',
         'Config',
         'State',
+        'ConversationMessage',
     ],
     endpoints: () => ({}),
 });


### PR DESCRIPTION
To avoid numerous redundant requests from getting re-issued on cache invalidation (all of the "after" requests were getting re-issued, resulting in 10s and even hundreds of requests being issued)