### PR TITLE
Deletes old context_transfer assistants

### DIFF
--- a/assistants/navigator-assistant/assistant/response/local_tool/add_assistant_to_conversation.py
+++ b/assistants/navigator-assistant/assistant/response/local_tool/add_assistant_to_conversation.py
@@ -54,7 +54,13 @@ async def assistant_card(args: ArgumentModel, context: ConversationContext) -> s
             args.assistant_service_id,
             args.template_id,
         )
-        return "Error: The selected assistant_service_id and template_id are not available."
+        return (
+            "Error: The selected assistant_service_id and template_id are not available. For reference, the available assistants are:\n\n"
+            + "\n\n".join([
+                f"assistant_service_id: {assistant_service_id}, template_id: {template.id}\nname: {template.name}\n\n"
+                for assistant_service_id, template, _ in service_templates
+            ])
+        )
 
     await context.send_messages(
         NewConversationMessage(

--- a/workbench-service/migrations/versions/2025_05_19_163613_b2f86e981885_delete_context_transfer_assistants.py
+++ b/workbench-service/migrations/versions/2025_05_19_163613_b2f86e981885_delete_context_transfer_assistants.py
@@ -1,0 +1,41 @@
+"""delete context transfer assistants
+
+Revision ID: b2f86e981885
+Revises: 3763629295ad
+Create Date: 2025-05-19 16:36:13.739217
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2f86e981885"
+down_revision: Union[str, None] = "3763629295ad"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM assistant
+        WHERE assistant_service_id = 'project-assistant.made-exploration'
+        AND template_id = 'context_transfer'
+        """
+    )
+    op.execute(
+        """
+        UPDATE assistantparticipant
+        SET active_participant = false
+        WHERE assistant_id NOT IN (
+            SELECT assistant_id
+            FROM assistant
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Additionally improves "assistant_card" response to include available assistant services and templates if the model provides invalid ones.