### PR TITLE
Adds inline attachments to assistant-extensions

### DIFF
--- a/assistants/codespace-assistant/assistant/response/step_handler.py
+++ b/assistants/codespace-assistant/assistant/response/step_handler.py
@@ -8,7 +8,7 @@ from assistant_extensions.attachments import AttachmentsConfigModel, Attachments
 from assistant_extensions.mcp import MCPSession, OpenAISamplingHandler
 from assistant_extensions.virtual_filesystem import AttachmentsVirtualFileSystemFileSource
 from chat_context_toolkit.history import NewTurn
-from chat_context_toolkit.virtual_filesystem import VirtualFileSystem
+from chat_context_toolkit.virtual_filesystem import MountPoint, VirtualFileSystem
 from openai.types.chat import (
     ChatCompletion,
     ParsedChatCompletion,
@@ -81,8 +81,13 @@ async def next_step(
 
     virtual_filesystem = VirtualFileSystem()
     virtual_filesystem.mount(
-        "/attachments",
-        AttachmentsVirtualFileSystemFileSource(attachments_extension=attachments_extension, context=context),
+        MountPoint(
+            path="/attachments",
+            file_source=AttachmentsVirtualFileSystemFileSource(
+                attachments_extension=attachments_extension, context=context
+            ),
+            description="User and assistant created files and attachments",
+        )
     )
 
     tools = [tool for _, tool in virtual_filesystem.tools.items()]

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/__init__.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/__init__.py
@@ -1,4 +1,10 @@
-from ._attachments import AttachmentProcessingErrorHandler, AttachmentsExtension
+from ._attachments import AttachmentProcessingErrorHandler, AttachmentsExtension, get_attachments
 from ._model import Attachment, AttachmentsConfigModel
 
-__all__ = ["AttachmentsExtension", "AttachmentsConfigModel", "Attachment", "AttachmentProcessingErrorHandler"]
+__all__ = [
+    "AttachmentsExtension",
+    "AttachmentsConfigModel",
+    "Attachment",
+    "AttachmentProcessingErrorHandler",
+    "get_attachments",
+]

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
@@ -142,7 +142,7 @@ class AttachmentsExtension:
         """
 
         # get attachments, filtered by include_filenames and exclude_filenames
-        attachments = await _get_attachments(
+        attachments = await get_attachments(
             context,
             error_handler=self._error_handler,
             include_filenames=include_filenames,
@@ -167,7 +167,7 @@ class AttachmentsExtension:
         exclude_filenames: list[str] = [],
     ) -> list[str]:
         # get attachments, filtered by include_filenames and exclude_filenames
-        attachments = await _get_attachments(
+        attachments = await get_attachments(
             context,
             error_handler=self._error_handler,
             include_filenames=include_filenames,
@@ -227,11 +227,15 @@ def _create_message(preferred_message_role: str, content: str) -> CompletionMess
             raise ValueError(f"unsupported preferred_message_role: {preferred_message_role}")
 
 
-async def _get_attachments(
+async def default_error_handler(context: ConversationContext, filename: str, e: Exception) -> None:
+    logger.exception("error reading file %s", filename, exc_info=e)
+
+
+async def get_attachments(
     context: ConversationContext,
-    error_handler: AttachmentProcessingErrorHandler,
     include_filenames: list[str] | None,
     exclude_filenames: list[str],
+    error_handler: AttachmentProcessingErrorHandler = default_error_handler,
 ) -> Sequence[Attachment]:
     """
     Gets all attachments for the current state of the conversation, updating the cache as needed.

--- a/libraries/python/assistant-extensions/assistant_extensions/message_history/_history.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/message_history/_history.py
@@ -4,20 +4,103 @@ import logging
 import uuid
 from typing import Sequence
 
-from chat_context_toolkit.history import HistoryMessageProtocol, HistoryMessageProvider
-from chat_context_toolkit.history.tool_abbreviations import (
-    HistoryMessageWithToolAbbreviation,
-    ToolAbbreviations,
+from chat_context_toolkit.history import (
+    HistoryMessage,
+    HistoryMessageProtocol,
+    HistoryMessageProvider,
+    OpenAIHistoryMessageParam,
 )
+from chat_context_toolkit.history.tool_abbreviations import ToolAbbreviations, abbreviate_openai_tool_message
+from openai.types.chat import ChatCompletionContentPartTextParam, ChatCompletionUserMessageParam
 from semantic_workbench_api_model.workbench_model import (
     ConversationMessage,
     MessageType,
 )
 from semantic_workbench_assistant.assistant_app import ConversationContext
 
-from ._message import conversation_message_to_chat_message_params
+from ._message import conversation_message_to_chat_message_param
 
 logger = logging.getLogger(__name__)
+
+
+class HistoryMessageWithAbbreviation(HistoryMessage):
+    """
+    A HistoryMessageProtocol implementation that includes:
+    - abbreviations for tool messages
+    - abbreviations for assistant messages with tool calls
+    - abbreviations for messages with attachment content-parts
+    """
+
+    def __init__(
+        self,
+        id: str,
+        openai_message: OpenAIHistoryMessageParam,
+        tool_abbreviations: ToolAbbreviations,
+        tool_name_for_tool_message: str | None = None,
+    ) -> None:
+        super().__init__(id=id, openai_message=openai_message, abbreviator=self.abbreviator)
+        self._tool_abbreviations = tool_abbreviations
+        self._tool_name_for_tool_message = tool_name_for_tool_message
+
+    def abbreviator(self) -> OpenAIHistoryMessageParam | None:
+        match self.openai_message:
+            case {"role": "user"}:
+                return abbreviate_attachment_content_parts(openai_message=self.openai_message)
+            case {"role": "tool"} | {"role": "assistant"}:
+                return abbreviate_openai_tool_message(
+                    openai_message=self.openai_message,
+                    tool_abbreviations=self._tool_abbreviations,
+                    tool_name_for_tool_message=self._tool_name_for_tool_message,
+                )
+
+            case _:
+                # for all other messages, we return the original message
+                return self.openai_message
+
+
+def abbreviate_attachment_content_parts(
+    openai_message: ChatCompletionUserMessageParam,
+) -> OpenAIHistoryMessageParam:
+    """
+    Abbreviate the user message if it contains attachment content parts.
+    """
+    if "content" not in openai_message:
+        return openai_message
+
+    content_parts = openai_message["content"]
+    if not isinstance(content_parts, list):
+        return openai_message
+
+    # the first content-part is always the text content, so we can keep it as is
+    abbreviated_content_parts = [content_parts[0]]
+    for part in content_parts[1:]:
+        match part:
+            case {"type": "text"}:
+                # truncate the attachment content parts - ie. the one's that don't say "Attachment: <filename>"
+                if part["text"].startswith("Attachment: "):
+                    # Keep the attachment content parts as is
+                    abbreviated_content_parts.append(part)
+                    continue
+
+                abbreviated_content_parts.append(
+                    ChatCompletionContentPartTextParam(
+                        type="text",
+                        text="The content of this attachment has been removed due to token limits. Please use view to retrieve the most recent content if you need it.",
+                    )
+                )
+
+            case {"type": "image_url"}:
+                abbreviated_content_parts.append(
+                    ChatCompletionContentPartTextParam(
+                        type="text",
+                        text="The content of this attachment has been removed due to token limits. Please use view to retrieve the most recent content if you need it.",
+                    )
+                )
+
+            case _:
+                abbreviated_content_parts.append(part)
+
+    return {**openai_message, "content": abbreviated_content_parts}
 
 
 def chat_context_toolkit_message_provider_for(
@@ -37,7 +120,7 @@ def chat_context_toolkit_message_provider_for(
 
 async def _get_history_manager_messages(
     context: ConversationContext, after_id: str | None, tool_abbreviations: ToolAbbreviations
-) -> list[HistoryMessageWithToolAbbreviation]:
+) -> list[HistoryMessageWithAbbreviation]:
     """
     Get all messages in the conversation, formatted for the chat_context_toolkit.
     """
@@ -49,7 +132,7 @@ async def _get_history_manager_messages(
     # so we need to loop until all messages are retrieved
     # if token_limit is provided, we will stop when the token limit is reached
 
-    history: list[HistoryMessageWithToolAbbreviation] = []
+    history: list[HistoryMessageWithAbbreviation] = []
 
     page_size = 100
     before_message_id = None
@@ -67,21 +150,25 @@ async def _get_history_manager_messages(
         # set the before_message_id for the next batch of messages
         before_message_id = messages_list[0].id
 
-        page: list[HistoryMessageWithToolAbbreviation] = []
+        page: list[HistoryMessageWithAbbreviation] = []
         for message in messages_list:
             # format the message
-            formatted_message_list = await conversation_message_to_chat_message_params(context, message, participants)
+            formatted_message = await conversation_message_to_chat_message_param(context, message, participants)
+
+            if not formatted_message:
+                # if the message could not be formatted, skip it
+                logger.warning("message %s could not be formatted, skipping.", message.id)
+                continue
 
             # prepend the formatted messages to the history list
-            page.extend([
-                HistoryMessageWithToolAbbreviation(
+            page.append(
+                HistoryMessageWithAbbreviation(
                     id=str(message.id),
                     openai_message=formatted_message,
                     tool_abbreviations=tool_abbreviations,
                     tool_name_for_tool_message=tool_name_for_tool_message(message),
                 )
-                for formatted_message in formatted_message_list
-            ])
+            )
 
         # add the formatted messages to the history
         history = page + history

--- a/libraries/python/assistant-extensions/assistant_extensions/message_history/_message.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/message_history/_message.py
@@ -4,6 +4,8 @@ from typing import Any
 
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
+    ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartTextParam,
     ChatCompletionMessageToolCallParam,
     ChatCompletionToolMessageParam,
     ChatCompletionUserMessageParam,
@@ -14,6 +16,8 @@ from semantic_workbench_api_model.workbench_model import (
     MessageType,
 )
 from semantic_workbench_assistant.assistant_app import ConversationContext
+
+from ..attachments import get_attachments
 
 logger = logging.getLogger(__name__)
 
@@ -91,58 +95,118 @@ def conversation_message_to_assistant_message(
     return assistant_message
 
 
-def conversation_message_to_user_message(
+async def conversation_message_to_user_message(
+    context: ConversationContext,
     message: ConversationMessage,
     participants: list[ConversationParticipant],
 ) -> ChatCompletionUserMessageParam:
     """
-    Convert a conversation message to a user message.
+    Convert a conversation message to a user message. For messages with attachments, the attachments
+    are included as content parts.
     """
+
+    # if the message has no attachments, just return a user message with the formatted content
+    if not message.filenames:
+        return ChatCompletionUserMessageParam(
+            role="user",
+            content=format_message(message, participants),
+        )
+
+    # for messages with attachments, we need to create a user message with content parts
+
+    # include the formatted message from the user
+    content_parts: list[ChatCompletionContentPartTextParam | ChatCompletionContentPartImageParam] = [
+        ChatCompletionContentPartTextParam(
+            type="text",
+            text=format_message(message, participants),
+        )
+    ]
+
+    # additionally, include any attachments as content parts
+    for filename in message.filenames:
+        attachments = await get_attachments(context=context, include_filenames=[filename], exclude_filenames=[])
+
+        attachment_filename = f"/attachments/{filename}"
+
+        content_parts.append(
+            ChatCompletionContentPartTextParam(
+                type="text",
+                text=f"Attachment: {attachment_filename}",
+            )
+        )
+
+        if not attachments:
+            content_parts.append(
+                ChatCompletionContentPartTextParam(
+                    type="text",
+                    text="File has been deleted",
+                )
+            )
+            continue
+
+        attachment = attachments[0]
+
+        if attachment.error:
+            content_parts.append(
+                ChatCompletionContentPartTextParam(
+                    type="text",
+                    text=f"Attachment has an error: {attachment.error}",
+                )
+            )
+            continue
+
+        if attachment.content.startswith("data:image/"):
+            content_parts.append(
+                ChatCompletionContentPartImageParam(
+                    type="image_url",
+                    image_url={
+                        "url": attachment.content,
+                    },
+                )
+            )
+            continue
+
+        content_parts.append(
+            ChatCompletionContentPartTextParam(
+                type="text",
+                text=attachment.content or "(attachment has no content)",
+            )
+        )
+
     return ChatCompletionUserMessageParam(
         role="user",
-        content=format_message(message, participants),
+        content=content_parts,
     )
 
 
-async def conversation_message_to_chat_message_params(
+async def conversation_message_to_chat_message_param(
     context: ConversationContext, message: ConversationMessage, participants: list[ConversationParticipant]
-) -> list[ChatCompletionUserMessageParam | ChatCompletionAssistantMessageParam | ChatCompletionToolMessageParam]:
+) -> ChatCompletionUserMessageParam | ChatCompletionAssistantMessageParam | ChatCompletionToolMessageParam | None:
     """
     Convert a conversation message to a list of chat message parameters.
     """
-
-    # some messages may have multiple parts, such as a text message with an attachment
-    chat_message_params: list[
-        ChatCompletionUserMessageParam | ChatCompletionAssistantMessageParam | ChatCompletionToolMessageParam
-    ] = []
 
     # add the message to list, treating messages from a source other than this assistant as a user message
     if message.message_type == MessageType.note:
         # we are stuffing tool messages into the note message type, so we need to check for that
         tool_message = conversation_message_to_tool_message(message)
-        if tool_message is not None:
-            chat_message_params.append(tool_message)
-        else:
+        if tool_message is None:
             logger.warning(f"Failed to convert tool message to completion message: {message}")
+            return None
 
-    elif message.sender.participant_id == context.assistant.id:
+        return tool_message
+
+    if message.sender.participant_id == context.assistant.id:
         # add the assistant message to the completion messages
         assistant_message = conversation_message_to_assistant_message(message, participants)
-        chat_message_params.append(assistant_message)
+        return assistant_message
 
-    else:
-        # add the user message to the completion messages
-        user_message = conversation_message_to_user_message(message, participants)
-        chat_message_params.append(user_message)
+    # add the user message to the completion messages
+    user_message = await conversation_message_to_user_message(
+        context=context, message=message, participants=participants
+    )
 
-        # add the attachment message to the completion messages
-        if message.filenames and len(message.filenames) > 0:
-            # add a system message to indicate the attachments
-            chat_message_params.append(
-                ChatCompletionUserMessageParam(role="user", content=f"Attachment(s): {', '.join(message.filenames)}")
-            )
-
-    return chat_message_params
+    return user_message
 
 
 def format_message(message: ConversationMessage, participants: list[ConversationParticipant]) -> str:

--- a/libraries/python/assistant-extensions/assistant_extensions/virtual_filesystem/_attachments_file_source.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/virtual_filesystem/_attachments_file_source.py
@@ -9,7 +9,7 @@ from chat_context_toolkit.virtual_filesystem import (
 )
 from semantic_workbench_assistant.assistant_app import ConversationContext
 
-from assistant_extensions.attachments._attachments import AttachmentsExtension, _get_attachments
+from assistant_extensions.attachments import AttachmentsExtension, get_attachments
 
 logger = logging.getLogger(__name__)
 
@@ -79,11 +79,8 @@ class AttachmentsVirtualFileSystemFileSource(FileSource):
 
         workbench_path = path.lstrip("/")
 
-        async def error_handler(context: ConversationContext, filename: str, e: Exception) -> None:
-            logger.exception("error reading file %s", filename, exc_info=e)
-
-        attachments = await _get_attachments(
-            context=self.context, error_handler=error_handler, include_filenames=[workbench_path], exclude_filenames=[]
+        attachments = await get_attachments(
+            context=self.context, include_filenames=[workbench_path], exclude_filenames=[]
         )
         if not attachments:
             raise FileNotFoundError(f"File not found: {path}")

--- a/libraries/python/chat-context-toolkit/.claude/settings.local.json
+++ b/libraries/python/chat-context-toolkit/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make:*)"
+    ],
+    "deny": []
+  }
+}

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/history/__init__.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/history/__init__.py
@@ -1,9 +1,17 @@
 from ._history import apply_budget_to_history_messages
-from ._types import HistoryMessageProtocol, HistoryMessageProvider, NewTurn, OpenAIHistoryMessageParam, TokenCounter
+from ._types import (
+    HistoryMessage,
+    HistoryMessageProtocol,
+    HistoryMessageProvider,
+    NewTurn,
+    OpenAIHistoryMessageParam,
+    TokenCounter,
+)
 
 __all__ = [
     "apply_budget_to_history_messages",
     "HistoryMessageProtocol",
+    "HistoryMessage",
     "HistoryMessageProvider",
     "NewTurn",
     "OpenAIHistoryMessageParam",

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/history/tool_abbreviations/__init__.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/history/tool_abbreviations/__init__.py
@@ -1,7 +1,11 @@
-from ._tool_abbreviations import Abbreviations, HistoryMessageWithToolAbbreviation, ToolAbbreviations
+from ._tool_abbreviations import (
+    Abbreviations,
+    ToolAbbreviations,
+    abbreviate_openai_tool_message,
+)
 
 __all__ = [
     "ToolAbbreviations",
     "Abbreviations",
-    "HistoryMessageWithToolAbbreviation",
+    "abbreviate_openai_tool_message",
 ]

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/history/tool_abbreviations/_tool_abbreviations.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/history/tool_abbreviations/_tool_abbreviations.py
@@ -30,43 +30,11 @@ ToolAbbreviations = dict[str, Abbreviations]
 """A mapping of tool names to their abbreviations for assistant tool calls and tool messages."""
 
 
-class HistoryMessageWithToolAbbreviation:
-    """
-    A HistoryMessageProtocol implementation that includes an abbreviated OpenAI message representation
-    for tool messages and assistant messages with tool calls.
-    """
-
-    def __init__(
-        self,
-        id: str,
-        openai_message: OpenAIHistoryMessageParam,
-        tool_abbreviations: ToolAbbreviations,
-        tool_name_for_tool_message: str | None = None,
-    ) -> None:
-        self.id = id
-        self.openai_message = openai_message
-        self._abbreviated_openai_message_created = False
-        self._tool_abbreviations = tool_abbreviations
-        self._tool_name_for_tool_message = tool_name_for_tool_message
-
-    @property
-    def abbreviated_openai_message(self) -> OpenAIHistoryMessageParam | None:
-        if self._abbreviated_openai_message_created:
-            return self._abbreviated_openai_message
-        self._abbreviated_openai_message = abbreviate_openai_message(
-            tool_name_for_tool_message=self._tool_name_for_tool_message,
-            openai_message=self.openai_message,
-            tool_abbreviations=self._tool_abbreviations,
-        )
-        self._abbreviated_openai_message_created = True
-        return self._abbreviated_openai_message
-
-
-def abbreviate_openai_message(
+def abbreviate_openai_tool_message(
     openai_message: OpenAIHistoryMessageParam,
     tool_abbreviations: ToolAbbreviations,
     tool_name_for_tool_message: str | None = None,
-) -> OpenAIHistoryMessageParam | None:
+) -> OpenAIHistoryMessageParam:
     """
     Abbreviate the OpenAI message if it is a tool message or an assistant message with tool calls.
 
@@ -87,7 +55,8 @@ def abbreviate_openai_message(
         case {"role": "assistant", "tool_calls": tool_calls}:
             return abbreviate_tool_call_message(openai_message, tool_calls, tool_abbreviations)
 
-    return openai_message
+        case _:
+            return openai_message
 
 
 def abbreviate_tool_message(

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/virtual_filesystem/__init__.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/virtual_filesystem/__init__.py
@@ -1,12 +1,13 @@
 """Virtual file system for chat completions."""
 
-from .types import DirectoryEntry, FileEntry, FileSource, WriteToolDefinition
+from .types import DirectoryEntry, FileEntry, FileSource, WriteToolDefinition, MountPoint
 from .virtual_filesystem import VirtualFileSystem
 
 __all__ = [
     "DirectoryEntry",
     "FileEntry",
     "FileSource",
+    "MountPoint",
     "VirtualFileSystem",
     "WriteToolDefinition",
 ]

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/virtual_filesystem/types.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/virtual_filesystem/types.py
@@ -79,3 +79,17 @@ class FileSource(Protocol):
         FileSource implementations are responsible for representing the file content as a string.
         """
         ...
+
+
+@dataclass
+class MountPoint:
+    """Mount point for a file source in the virtual file system."""
+
+    path: str
+    """Mount path in the virtual file system, such as "/docs"."""
+
+    description: str
+    """Description of the mount point, used for informing the LLM about the content."""
+
+    file_source: FileSource
+    """The file source that is mounted at the specified path."""


### PR DESCRIPTION
The "history" extension now includes attachments inline

The attachments can be abbreviated and therefore better incorporated into the token budgeting

This PR also integrates this feature into the coespace-assistant