### PR TITLE
Summaries for attachments

### DIFF
--- a/assistants/codespace-assistant/assistant/response/step_handler.py
+++ b/assistants/codespace-assistant/assistant/response/step_handler.py
@@ -5,6 +5,7 @@ from typing import Any, List
 
 import deepmerge
 from assistant_extensions.attachments import AttachmentsExtension
+from assistant_extensions.chat_context_toolkit.message_history import chat_context_toolkit_message_provider_for
 from assistant_extensions.chat_context_toolkit.virtual_filesystem import (
     archive_file_source_mount,
     attachments_file_source_mount,
@@ -28,6 +29,7 @@ from .completion_handler import handle_completion
 from .models import StepResult
 from .request_builder import build_request
 from .utils import (
+    abbreviations,
     get_completion,
     get_formatted_token_count,
     get_openai_tools_from_mcp_sessions,
@@ -83,7 +85,7 @@ async def next_step(
 
     virtual_filesystem = VirtualFileSystem(
         mounts=[
-            attachments_file_source_mount(attachments_extension, context),
+            attachments_file_source_mount(context, service_config=service_config, request_config=request_config),
             archive_file_source_mount(context),
         ]
     )
@@ -102,6 +104,12 @@ async def next_step(
         tools=tools,
         silence_token=silence_token,
         history_turn=history_turn,
+        history_message_provider=chat_context_toolkit_message_provider_for(
+            context=context,
+            tool_abbreviations=abbreviations.tool_abbreviations,
+            service_config=service_config,
+            request_config=request_config,
+        ),
     )
 
     chat_message_params = build_request_result.chat_message_params

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_attachments.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, Awaitable, Callable, Sequence
 
 import openai_client
-from assistant_drive import Drive, DriveConfig, IfDriveFileExistsBehavior
+from assistant_drive import IfDriveFileExistsBehavior
 from llm_client.model import CompletionMessage, CompletionMessageImageContent, CompletionMessageTextContent
 from semantic_workbench_api_model.workbench_model import (
     ConversationEvent,
@@ -17,11 +17,17 @@ from semantic_workbench_assistant.assistant_app import (
     AssistantAppProtocol,
     AssistantCapability,
     ConversationContext,
-    storage_directory_for_context,
 )
 
 from . import _convert as convert
-from ._model import Attachment, AttachmentsConfigModel
+from ._model import Attachment, AttachmentsConfigModel, AttachmentSummary, Summarizer
+from ._shared import (
+    attachment_drive_for_context,
+    attachment_to_original_filename,
+    original_to_attachment_filename,
+    summary_drive_for_context,
+)
+from ._summarizer import get_attachment_summary, summarize_attachment_task
 
 logger = logging.getLogger(__name__)
 
@@ -99,17 +105,6 @@ class AttachmentsExtension:
 
         # listen for file events for to pro-actively update and delete attachments
 
-        @assistant.events.conversation.file.on_created_including_mine
-        @assistant.events.conversation.file.on_updated_including_mine
-        async def on_file_created_or_updated(
-            context: ConversationContext, event: ConversationEvent, file: File
-        ) -> None:
-            """
-            Cache an attachment when a file is created or updated in the conversation.
-            """
-
-            await _get_attachment_for_file(context, file, {}, error_handler=self._error_handler)
-
         @assistant.events.conversation.file.on_deleted_including_mine
         async def on_file_deleted(context: ConversationContext, event: ConversationEvent, file: File) -> None:
             """
@@ -125,6 +120,7 @@ class AttachmentsExtension:
         config: AttachmentsConfigModel,
         include_filenames: list[str] | None = None,
         exclude_filenames: list[str] = [],
+        summarizer: Summarizer | None = None,
     ) -> Sequence[CompletionMessage]:
         """
         Generate user messages for each attachment that includes the filename and content.
@@ -166,20 +162,17 @@ class AttachmentsExtension:
         include_filenames: list[str] | None = None,
         exclude_filenames: list[str] = [],
     ) -> list[str]:
-        # get attachments, filtered by include_filenames and exclude_filenames
-        attachments = await get_attachments(
-            context,
-            error_handler=self._error_handler,
-            include_filenames=include_filenames,
-            exclude_filenames=exclude_filenames,
-        )
+        files_response = await context.list_files()
 
-        if not attachments:
-            return []
+        # for all files, get the attachment
+        for file in files_response.files:
+            if include_filenames is not None and file.filename not in include_filenames:
+                continue
+            if file.filename in exclude_filenames:
+                continue
 
-        filenames: list[str] = []
-        for attachment in attachments:
-            filenames.append(attachment.filename)
+        # delete cached attachments that are no longer in the conversation
+        filenames = list({file.filename for file in files_response.files})
 
         return filenames
 
@@ -236,6 +229,7 @@ async def get_attachments(
     include_filenames: list[str] | None,
     exclude_filenames: list[str],
     error_handler: AttachmentProcessingErrorHandler = default_error_handler,
+    summarizer: Summarizer | None = None,
 ) -> Sequence[Attachment]:
     """
     Gets all attachments for the current state of the conversation, updating the cache as needed.
@@ -252,7 +246,7 @@ async def get_attachments(
         if file.filename in exclude_filenames:
             continue
 
-        attachment = await _get_attachment_for_file(context, file, {}, error_handler)
+        attachment = await _get_attachment_for_file(context, file, {}, error_handler, summarizer=summarizer)
         attachments.append(attachment)
 
     # delete cached attachments that are no longer in the conversation
@@ -264,14 +258,21 @@ async def get_attachments(
 
 async def _delete_attachments_not_in(context: ConversationContext, filenames: set[str]) -> None:
     """Deletes cached attachments that are not in the filenames argument."""
-    drive = _attachment_drive_for_context(context)
+    drive = attachment_drive_for_context(context)
+    summary_drive = summary_drive_for_context(context)
     for attachment_filename in drive.list():
-        original_file_name = _attachment_to_original_filename(attachment_filename)
+        if attachment_filename == "summaries":
+            continue
+
+        original_file_name = attachment_to_original_filename(attachment_filename)
         if original_file_name in filenames:
             continue
 
         with contextlib.suppress(FileNotFoundError):
             drive.delete(attachment_filename)
+
+        with contextlib.suppress(FileNotFoundError):
+            summary_drive.delete(attachment_filename)
 
         await _delete_lock_for_context_file(context, original_file_name)
 
@@ -301,91 +302,133 @@ async def _lock_for_context_file(context: ConversationContext, filename: str) ->
         return _file_locks[key]
 
 
-def _original_to_attachment_filename(filename: str) -> str:
-    return filename + ".json"
-
-
-def _attachment_to_original_filename(filename: str) -> str:
-    return filename.removesuffix(".json")
-
-
 async def _get_attachment_for_file(
-    context: ConversationContext, file: File, metadata: dict[str, Any], error_handler: AttachmentProcessingErrorHandler
+    context: ConversationContext,
+    file: File,
+    metadata: dict[str, Any],
+    error_handler: AttachmentProcessingErrorHandler,
+    summarizer: Summarizer | None = None,
 ) -> Attachment:
     """
     Get the attachment for the file. If the attachment is not cached, or the file is
     newer than the cached attachment, the text content of the file will be extracted
     and the cache will be updated.
     """
-    drive = _attachment_drive_for_context(context)
 
     # ensure that only one async task is updating the attachment for the file
     file_lock = await _lock_for_context_file(context, file.filename)
     async with file_lock:
-        with contextlib.suppress(FileNotFoundError):
-            attachment = drive.read_model(Attachment, _original_to_attachment_filename(file.filename))
-
-            if attachment.updated_datetime.timestamp() >= file.updated_datetime.timestamp():
-                # if the attachment is up-to-date, return it
-                return attachment
-
-        content = ""
-        error = ""
-        # process the file to create an attachment
-        async with context.set_status(f"updating attachment {file.filename}..."):
-            try:
-                # read the content of the file
-                file_bytes = await _read_conversation_file(context, file)
-                # convert the content of the file to a string
-                content = await convert.bytes_to_str(file_bytes, filename=file.filename)
-            except Exception as e:
-                await error_handler(context, file.filename, e)
-                error = f"error processing file: {e}"
-
-        attachment = Attachment(
-            filename=file.filename,
-            content=content,
+        attachment = await _get_or_update_attachment(
+            context=context,
+            file=file,
             metadata=metadata,
-            updated_datetime=file.updated_datetime,
-            error=error,
-        )
-        drive.write_model(
-            attachment, _original_to_attachment_filename(file.filename), if_exists=IfDriveFileExistsBehavior.OVERWRITE
+            error_handler=error_handler,
         )
 
-        completion_message = _create_message_for_attachment(preferred_message_role="system", attachment=attachment)
-        openai_completion_messages = openai_client.messages.convert_from_completion_messages([completion_message])
-        token_count = openai_client.num_tokens_from_message(openai_completion_messages[0], model="gpt-4o")
+        summary = AttachmentSummary(summary="")
+        if summarizer:
+            summary = await _get_or_update_attachment_summary(
+                context=context,
+                attachment=attachment,
+                summarizer=summarizer,
+            )
 
-        # update the conversation token count based on the token count of the latest version of this file
-        prior_token_count = file.metadata.get("token_count", 0)
-        conversation = await context.get_conversation()
-        token_counts = conversation.metadata.get("token_counts", {})
-        if token_counts:
-            total = token_counts.get("total", 0)
-            total += token_count - prior_token_count
-            await context.update_conversation({
-                "token_counts": {
-                    **token_counts,
-                    "total": total,
-                },
-            })
+    return attachment.model_copy(update={"summary": summary})
 
-        await context.update_file(
-            file.filename,
-            metadata={
-                "token_count": token_count,
+
+async def _get_or_update_attachment(
+    context: ConversationContext, file: File, metadata: dict[str, Any], error_handler: AttachmentProcessingErrorHandler
+) -> Attachment:
+    drive = attachment_drive_for_context(context)
+
+    with contextlib.suppress(FileNotFoundError):
+        attachment = drive.read_model(Attachment, original_to_attachment_filename(file.filename))
+
+        if attachment.updated_datetime.timestamp() >= file.updated_datetime.timestamp():
+            # if the attachment is up-to-date, return it
+            return attachment
+
+    content = ""
+    error = ""
+    # process the file to create an attachment
+    async with context.set_status(f"updating attachment {file.filename}..."):
+        try:
+            # read the content of the file
+            file_bytes = await _read_conversation_file(context, file)
+            # convert the content of the file to a string
+            content = await convert.bytes_to_str(file_bytes, filename=file.filename)
+        except Exception as e:
+            await error_handler(context, file.filename, e)
+            error = f"error processing file: {e}"
+
+    attachment = Attachment(
+        filename=file.filename,
+        content=content,
+        metadata=metadata,
+        updated_datetime=file.updated_datetime,
+        error=error,
+    )
+    drive.write_model(
+        attachment, original_to_attachment_filename(file.filename), if_exists=IfDriveFileExistsBehavior.OVERWRITE
+    )
+
+    completion_message = _create_message_for_attachment(preferred_message_role="system", attachment=attachment)
+    openai_completion_messages = openai_client.messages.convert_from_completion_messages([completion_message])
+    token_count = openai_client.num_tokens_from_message(openai_completion_messages[0], model="gpt-4o")
+
+    # update the conversation token count based on the token count of the latest version of this file
+    prior_token_count = file.metadata.get("token_count", 0)
+    conversation = await context.get_conversation()
+    token_counts = conversation.metadata.get("token_counts", {})
+    if token_counts:
+        total = token_counts.get("total", 0)
+        total += token_count - prior_token_count
+        await context.update_conversation({
+            "token_counts": {
+                **token_counts,
+                "total": total,
             },
+        })
+
+    await context.update_file(
+        file.filename,
+        metadata={
+            "token_count": token_count,
+        },
+    )
+
+    return attachment
+
+
+async def _get_or_update_attachment_summary(
+    context: ConversationContext, attachment: Attachment, summarizer: Summarizer
+) -> AttachmentSummary:
+    attachment_summary = await get_attachment_summary(
+        context=context,
+        filename=attachment.filename,
+    )
+    if attachment_summary.updated_datetime.timestamp() < attachment.updated_datetime.timestamp():
+        # if the summary is not up-to-date, schedule a task to update it
+        asyncio.create_task(
+            summarize_attachment_task(
+                context=context,
+                summarizer=summarizer,
+                attachment=attachment,
+            )
         )
 
-        return attachment
+    return attachment_summary
 
 
 async def _delete_attachment_for_file(context: ConversationContext, file: File) -> None:
-    drive = _attachment_drive_for_context(context)
+    drive = attachment_drive_for_context(context)
 
     with contextlib.suppress(FileNotFoundError):
         drive.delete(file.filename)
+
+    summary_drive = summary_drive_for_context(context)
+    with contextlib.suppress(FileNotFoundError):
+        summary_drive.delete(file.filename)
 
     await _delete_lock_for_context_file(context, file.filename)
 
@@ -411,14 +454,6 @@ async def _delete_attachment_for_file(context: ConversationContext, file: File) 
             "total": total,
         },
     })
-
-
-def _attachment_drive_for_context(context: ConversationContext) -> Drive:
-    """
-    Get the Drive instance for the attachments.
-    """
-    drive_root = storage_directory_for_context(context) / "attachments"
-    return Drive(DriveConfig(root=drive_root))
 
 
 async def _read_conversation_file(context: ConversationContext, file: File) -> bytes:

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_model.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_model.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Protocol
 
 from pydantic import BaseModel, Field
 from semantic_workbench_assistant.config import UISchema
@@ -32,5 +32,28 @@ class Attachment(BaseModel):
     filename: str
     content: str = ""
     error: str = ""
+    summary: str = ""
     metadata: dict[str, Any] = {}
     updated_datetime: datetime.datetime = Field(default=datetime.datetime.fromtimestamp(0, datetime.timezone.utc))
+
+
+class AttachmentSummary(BaseModel):
+    """
+    A model representing a summary of an attachment.
+    """
+
+    summary: str
+    updated_datetime: datetime.datetime = Field(default=datetime.datetime.fromtimestamp(0, datetime.timezone.utc))
+
+
+class Summarizer(Protocol):
+    """
+    A protocol for a summarizer that can summarize attachment content.
+    """
+
+    async def summarize(self, attachment: Attachment) -> str:
+        """
+        Summarize the content of the attachment.
+        Returns the summary.
+        """
+        ...

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_shared.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_shared.py
@@ -1,0 +1,28 @@
+from assistant_drive import Drive, DriveConfig
+from semantic_workbench_assistant.assistant_app import (
+    ConversationContext,
+    storage_directory_for_context,
+)
+
+
+def attachment_drive_for_context(context: ConversationContext) -> Drive:
+    """
+    Get the Drive instance for the attachments.
+    """
+    drive_root = storage_directory_for_context(context) / "attachments"
+    return Drive(DriveConfig(root=drive_root))
+
+
+def summary_drive_for_context(context: ConversationContext) -> Drive:
+    """
+    Get the path to the summary drive for the attachments.
+    """
+    return attachment_drive_for_context(context).subdrive("summaries")
+
+
+def original_to_attachment_filename(filename: str) -> str:
+    return filename + ".json"
+
+
+def attachment_to_original_filename(filename: str) -> str:
+    return filename.removesuffix(".json")

--- a/libraries/python/assistant-extensions/assistant_extensions/attachments/_summarizer.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/attachments/_summarizer.py
@@ -1,0 +1,109 @@
+import datetime
+import logging
+from typing import Callable
+
+from attr import dataclass
+from openai import AsyncOpenAI
+from openai.types.chat import (
+    ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartTextParam,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionUserMessageParam,
+)
+from semantic_workbench_assistant.assistant_app import ConversationContext
+
+from ._model import Attachment, AttachmentSummary, Summarizer
+from ._shared import original_to_attachment_filename, summary_drive_for_context
+
+logger = logging.getLogger("assistant_extensions.attachments")
+
+
+async def get_attachment_summary(context: ConversationContext, filename: str) -> AttachmentSummary:
+    """
+    Get the summary of the attachment from the summary drive.
+    If the summary file does not exist, returns None.
+    """
+    drive = summary_drive_for_context(context)
+
+    try:
+        return drive.read_model(AttachmentSummary, original_to_attachment_filename(filename))
+
+    except FileNotFoundError:
+        # If the summary file does not exist, return None
+        return AttachmentSummary(
+            summary="",
+        )
+
+
+async def summarize_attachment_task(
+    context: ConversationContext, summarizer: Summarizer, attachment: Attachment
+) -> None:
+    """
+    Summarize the attachment and save the summary to the summary drive.
+    """
+
+    logger.info("summarizing attachment; filename: %s", attachment.filename)
+
+    summary = await summarizer.summarize(attachment=attachment)
+
+    attachment_summary = AttachmentSummary(summary=summary, updated_datetime=datetime.datetime.now(datetime.UTC))
+
+    drive = summary_drive_for_context(context)
+    # Save the summary
+    drive.write_model(attachment_summary, original_to_attachment_filename(attachment.filename))
+
+    logger.info("summarization of attachment complete; filename: %s", attachment.filename)
+
+
+@dataclass
+class LLMConfig:
+    client_factory: Callable[[], AsyncOpenAI]
+    model: str
+    max_response_tokens: int
+
+    file_summary_system_message: str = """You will be provided the content of a file.
+It is your goal to factually, accurately, and concisely summarize the content of the file.
+You must do so in less than 3 sentences or 100 words."""
+
+
+class LLMFileSummarizer(Summarizer):
+    def __init__(self, llm_config: LLMConfig) -> None:
+        self.llm_config = llm_config
+
+    async def summarize(self, attachment: Attachment) -> str:
+        llm_config = self.llm_config
+
+        content_param = ChatCompletionContentPartTextParam(type="text", text=attachment.content)
+        if attachment.content.startswith("data:image/"):
+            # If the content is an image, we need to provide a different message format
+            content_param = ChatCompletionContentPartImageParam(
+                type="image_url",
+                image_url={"url": attachment.content},
+            )
+
+        chat_message_params = [
+            ChatCompletionSystemMessageParam(role="system", content=llm_config.file_summary_system_message),
+            ChatCompletionUserMessageParam(
+                role="user",
+                content=[
+                    ChatCompletionContentPartTextParam(
+                        type="text",
+                        text=f"Filename: {attachment.filename}",
+                    ),
+                    content_param,
+                    ChatCompletionContentPartTextParam(
+                        type="text",
+                        text="Please concisely and accurately summarize the file contents.",
+                    ),
+                ],
+            ),
+        ]
+
+        async with llm_config.client_factory() as client:
+            summary_response = await client.chat.completions.create(
+                messages=chat_message_params,
+                model=llm_config.model,
+                max_tokens=llm_config.max_response_tokens,
+            )
+
+        return summary_response.choices[0].message.content or ""

--- a/libraries/python/assistant-extensions/assistant_extensions/chat_context_toolkit/archive/_archive.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/chat_context_toolkit/archive/_archive.py
@@ -45,9 +45,16 @@ class ArchiveStorageProvider(StorageProvider):
         return [file.relative_to(self.root_path) for file in path.iterdir()]
 
 
-def archive_message_provider_for(context: ConversationContext) -> ArchiveMessageProvider:
+def archive_message_provider_for(
+    context: ConversationContext, service_config: ServiceConfig, request_config: OpenAIRequestConfig
+) -> ArchiveMessageProvider:
     """Create an archive message provider for the provided context."""
-    return chat_context_toolkit_message_provider_for(context=context, tool_abbreviations=ToolAbbreviations())
+    return chat_context_toolkit_message_provider_for(
+        context=context,
+        tool_abbreviations=ToolAbbreviations(),
+        service_config=service_config,
+        request_config=request_config,
+    )
 
 
 def _archive_task_queue_for(
@@ -63,7 +70,9 @@ def _archive_task_queue_for(
     """
     return ArchiveTaskQueue(
         storage_provider=ArchiveStorageProvider(context=context, sub_directory=archive_storage_sub_directory),
-        message_provider=archive_message_provider_for(context=context),
+        message_provider=archive_message_provider_for(
+            context=context, service_config=service_config, request_config=request_config
+        ),
         token_counter=lambda messages: num_tokens_from_messages(messages=messages, model=token_counting_model),
         summarizer=LLMArchiveSummarizer(
             client_factory=lambda: create_client(service_config),
@@ -106,5 +115,4 @@ def archive_reader_for(context: ConversationContext, archive_storage_sub_directo
     """
     return ArchiveReader(
         storage_provider=ArchiveStorageProvider(context=context, sub_directory=archive_storage_sub_directory),
-        message_provider=archive_message_provider_for(context=context),
     )

--- a/libraries/python/assistant-extensions/assistant_extensions/chat_context_toolkit/archive/_summarizer.py
+++ b/libraries/python/assistant-extensions/assistant_extensions/chat_context_toolkit/archive/_summarizer.py
@@ -48,14 +48,14 @@ def convert_oai_messages_to_xml(oai_messages: list[ChatCompletionMessageParam]) 
     """
     Converts OpenAI messages to an XML-like formatted string.
     Example:
-    <conversation filename="conversation_20250520_201521_20250520_201521.txt">
+    <conversation>
     <message role="user">
     message content here
     </message>
     <message role="assistant">
     message content here
     <toolcall name="tool_name">
-    tool content here
+    tool arguments here
     </toolcall>
     </message>
     <message role="tool">

--- a/libraries/python/chat-context-toolkit/chat_context_toolkit/archive/_archive_reader.py
+++ b/libraries/python/chat-context-toolkit/chat_context_toolkit/archive/_archive_reader.py
@@ -1,4 +1,5 @@
 from typing import AsyncIterable
+
 from ._state import StateStorage
 from ._types import (
     CONTENT_SUB_DIR_PATH,
@@ -6,7 +7,6 @@ from ._types import (
     ArchiveContent,
     ArchiveManifest,
     ArchivesState,
-    MessageProvider,
     StorageProvider,
 )
 
@@ -14,12 +14,10 @@ from ._types import (
 class ArchiveReader:
     def __init__(
         self,
-        message_provider: MessageProvider,
         storage_provider: StorageProvider,
     ) -> None:
         self._state_storage = StateStorage(storage_provider)
         self._storage_provider = storage_provider
-        self._message_provider = message_provider
 
     async def get_state(self) -> ArchivesState:
         """


### PR DESCRIPTION
- uses LLM completion to summarize attachments in async tasks
- summaries are provided from the AttachmentFileSource as the `FileEntry.description` field
- summaries are included in `ls` tool response (just like for archive files)
- the summarizer is a protocol so folks can provide their own if they want