### PR TITLE
chore: remove aarontamasfe.even-better-toml VS Code extension

### DIFF
--- a/libraries/python/assistant-drive/.vscode/extensions.json
+++ b/libraries/python/assistant-drive/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "aarontamasfe.even-better-toml",
     "charliermarsh.ruff",
     "ms-python.python"
   ]


### PR DESCRIPTION
## Summary
- Remove the no longer maintained `aarontamasfe.even-better-toml` VS Code extension recommendation from VS Code extensions configuration
- This extension is being cleaned up across all team repositories as it is no longer maintained

## Changes
- Removed extension recommendation from `libraries/python/assistant-drive/.vscode/extensions.json`

## Test plan
- ✅ Verified extension recommendation has been removed from the extensions file
- No functional changes to tooling or code behavior

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)